### PR TITLE
Port Matrix overhaul from rivr-app testA to repos/person

### DIFF
--- a/src/app/(main)/messages/page.tsx
+++ b/src/app/(main)/messages/page.tsx
@@ -26,6 +26,11 @@ import {
   leaveRoom,
 } from "@/lib/matrix-client";
 import {
+  onMatrixSyncRepair,
+  MATRIX_SYNC_REPAIR_EXHAUSTED,
+} from "@/lib/matrix-sync-events";
+import { toast } from "@/components/ui/use-toast";
+import {
   getMatrixCredentials,
   getDmRoomForListing,
   getDmRoomForUser,
@@ -181,6 +186,25 @@ export default function MessagesPage() {
   );
 
   /**
+   * Subscribe to Matrix sync-repair events. We surface the "exhausted"
+   * state to users as a toast so they aren't silently stuck with stale
+   * DM mappings after a Synapse hiccup.
+   */
+  useEffect(() => {
+    const unsubscribe = onMatrixSyncRepair((evt) => {
+      if (evt.type === MATRIX_SYNC_REPAIR_EXHAUSTED) {
+        toast({
+          title: "Could not sync direct-message list",
+          description:
+            "Your conversation list may be stale. Refresh to retry; messages already received are safe.",
+          variant: "destructive",
+        });
+      }
+    });
+    return unsubscribe;
+  }, []);
+
+  /**
    * Initialize Matrix client, start sync, populate conversations.
    */
   useEffect(() => {
@@ -285,10 +309,13 @@ export default function MessagesPage() {
           : await getDmRoomForListing(listingIdParam!);
         if (cancelled || !result) return;
 
-        // Find or create a DM room with that Matrix user
+        // Find or create a DM room with that Matrix user. Pass the agent id
+        // (only when we got here via `?user=` deep-link, not via the listing
+        // path) so the dm_rooms mirror is populated.
         const roomId = await getOrCreateDmRoom(
           matrixClient,
-          result.targetMatrixUserId
+          result.targetMatrixUserId,
+          userIdParam ?? undefined,
         );
         if (cancelled) return;
 
@@ -340,13 +367,18 @@ export default function MessagesPage() {
         let roomId: string;
 
         if (agentIds.length === 1) {
-          // Single user — find or create 1-on-1 DM
+          // Single user — find or create 1-on-1 DM. Passing the agent id
+          // lets the helper mirror the room into RIVR's dm_rooms table.
           const result = await getDmRoomForUser(agentIds[0]);
           if (!result) {
             console.error("[messages] Could not resolve Matrix user ID for agent");
             return;
           }
-          roomId = await getOrCreateDmRoom(matrixClient, result.targetMatrixUserId);
+          roomId = await getOrCreateDmRoom(
+            matrixClient,
+            result.targetMatrixUserId,
+            agentIds[0],
+          );
         } else {
           // Multiple users — create a group DM
           const matrixUserIds = await getMatrixUserIdsForAgents(agentIds);
@@ -354,7 +386,12 @@ export default function MessagesPage() {
             console.error("[messages] No Matrix user IDs resolved for selected agents");
             return;
           }
-          roomId = await createGroupDmRoom(matrixClient, matrixUserIds);
+          roomId = await createGroupDmRoom(
+            matrixClient,
+            matrixUserIds,
+            undefined,
+            agentIds,
+          );
         }
 
         // Refresh conversations to include the new room
@@ -368,6 +405,25 @@ export default function MessagesPage() {
       }
     },
     [matrixClient, refreshConversations]
+  );
+
+  /**
+   * Handle add-to-chat side effects from MatrixChatPanel.
+   *
+   * If the action promoted a 1:1 DM into a fresh group room, the server has
+   * already created the new room + force-joined participants; we just need
+   * to refresh the conversation list and navigate to the new room.
+   */
+  const handleParticipantsAdded = useCallback(
+    (result: { promotedRoomId: string | null }) => {
+      if (!matrixClient) return;
+      refreshConversations(matrixClient);
+      if (result.promotedRoomId) {
+        setActiveRoomId(result.promotedRoomId);
+        setShowConversationList(false);
+      }
+    },
+    [matrixClient, refreshConversations],
   );
 
   /** Handle deleting a conversation: leave the Matrix room and remove from list. */
@@ -441,6 +497,7 @@ export default function MessagesPage() {
               matrixRoomId={activeRoomId}
               currentUserId={currentUserId}
               onBack={handleBack}
+              onParticipantsAdded={handleParticipantsAdded}
             />
           ) : (
             <MatrixChatPanel
@@ -450,6 +507,7 @@ export default function MessagesPage() {
               roomName={activeConversation.name}
               roomAvatarUrl={activeConversation.avatarUrl}
               onBack={handleBack}
+              onParticipantsAdded={handleParticipantsAdded}
             />
           )
         ) : (

--- a/src/app/actions/__tests__/matrix.test.ts
+++ b/src/app/actions/__tests__/matrix.test.ts
@@ -38,11 +38,30 @@ vi.mock("@/lib/matrix-admin", () => ({
     accessToken: "syt_test_token",
   }),
   adminJoinRoom: vi.fn().mockResolvedValue(undefined),
+  getRoomMembers: vi.fn().mockResolvedValue([]),
+  createGroupRoomAsAdmin: vi.fn().mockResolvedValue({ roomId: "!newgroup:matrix.local" }),
+  postSystemNotice: vi.fn().mockResolvedValue({ eventId: "$evt:matrix.local" }),
+}));
+
+vi.mock("@/lib/matrix-errors", () => ({
+  MatrixProvisioningError: class MatrixProvisioningError extends Error {
+    public readonly stage: string;
+    constructor(stage: string, message: string) {
+      super(message);
+      this.stage = stage;
+    }
+  },
 }));
 
 // Import AFTER all mocks
 import { auth } from "@/auth";
-import { provisionMatrixUser, adminJoinRoom } from "@/lib/matrix-admin";
+import {
+  provisionMatrixUser,
+  adminJoinRoom,
+  getRoomMembers,
+  createGroupRoomAsAdmin,
+  postSystemNotice,
+} from "@/lib/matrix-admin";
 import {
   getMatrixCredentials,
   getDmRoomForUser,
@@ -50,6 +69,7 @@ import {
   ensureUserJoinedRoom,
   getDmRoomForListing,
   getUserGroupRooms,
+  addParticipantsToRoom,
 } from "../matrix";
 
 // =============================================================================
@@ -377,6 +397,174 @@ describe("matrix actions", () => {
 
         const result = await getUserGroupRooms();
         expect(result).toEqual([]);
+      }));
+  });
+
+  // ===========================================================================
+  // addParticipantsToRoom
+  // ===========================================================================
+
+  describe("addParticipantsToRoom", () => {
+    beforeEach(() => {
+      vi.mocked(getRoomMembers).mockReset().mockResolvedValue([]);
+      vi.mocked(createGroupRoomAsAdmin)
+        .mockReset()
+        .mockResolvedValue({ roomId: "!newgroup:matrix.local" });
+      vi.mocked(postSystemNotice)
+        .mockReset()
+        .mockResolvedValue({ eventId: "$evt:matrix.local" });
+      vi.mocked(adminJoinRoom).mockReset().mockResolvedValue(undefined);
+    });
+
+    it("rejects every agent with 'Not authenticated' when no session", () =>
+      withTestTransaction(async () => {
+        vi.mocked(auth).mockResolvedValue(mockUnauthenticated());
+        const result = await addParticipantsToRoom("!room:matrix.local", ["a", "b"]);
+        expect(result.added).toEqual([]);
+        expect(result.failed).toEqual([
+          { agentId: "a", reason: "Not authenticated" },
+          { agentId: "b", reason: "Not authenticated" },
+        ]);
+        expect(result.promotedToRoomId).toBeNull();
+      }));
+
+    it("returns invalid-roomId failures for malformed room IDs", () =>
+      withTestTransaction(async (db) => {
+        const user = await createTestAgent(db);
+        vi.mocked(auth).mockResolvedValue(mockAuthSession(user.id));
+        const result = await addParticipantsToRoom("bad-room", ["x"]);
+        expect(result.added).toEqual([]);
+        expect(result.failed[0].reason).toMatch(/must start with !/);
+      }));
+
+    it("force-joins each agent into the room when it has 3+ members", () =>
+      withTestTransaction(async (db) => {
+        const user = await createTestAgent(db, {
+          matrixUserId: "@me:matrix.local",
+          matrixAccessToken: "syt_me",
+        });
+        const target = await createTestAgent(db, {
+          matrixUserId: "@target:matrix.local",
+          matrixAccessToken: "syt_target",
+        });
+        vi.mocked(auth).mockResolvedValue(mockAuthSession(user.id));
+        vi.mocked(getRoomMembers).mockResolvedValueOnce([
+          "@me:matrix.local",
+          "@a:matrix.local",
+          "@b:matrix.local",
+        ]);
+
+        const result = await addParticipantsToRoom(
+          "!group:matrix.local",
+          [target.id],
+        );
+
+        expect(result.added).toEqual([target.id]);
+        expect(result.failed).toEqual([]);
+        expect(result.promotedToRoomId).toBeNull();
+        expect(vi.mocked(adminJoinRoom)).toHaveBeenCalledWith({
+          userId: "@target:matrix.local",
+          roomId: "!group:matrix.local",
+        });
+        expect(vi.mocked(createGroupRoomAsAdmin)).not.toHaveBeenCalled();
+      }));
+
+    it("promotes a 1:1 DM to a new group room and force-joins everyone", () =>
+      withTestTransaction(async (db) => {
+        const user = await createTestAgent(db, {
+          matrixUserId: "@me:matrix.local",
+          matrixAccessToken: "syt_me",
+        });
+        const partner = await createTestAgent(db, {
+          matrixUserId: "@partner:matrix.local",
+          matrixAccessToken: "syt_partner",
+        });
+        const newAgent = await createTestAgent(db, {
+          matrixUserId: "@newcomer:matrix.local",
+          matrixAccessToken: "syt_newcomer",
+        });
+        vi.mocked(auth).mockResolvedValue(mockAuthSession(user.id));
+        vi.mocked(getRoomMembers).mockResolvedValueOnce([
+          "@me:matrix.local",
+          "@partner:matrix.local",
+        ]);
+
+        const result = await addParticipantsToRoom(
+          "!dm:matrix.local",
+          [newAgent.id],
+        );
+
+        expect(result.promotedToRoomId).toBe("!newgroup:matrix.local");
+        expect(result.added).toEqual([newAgent.id]);
+        expect(vi.mocked(createGroupRoomAsAdmin)).toHaveBeenCalledTimes(1);
+        const createCall = vi.mocked(createGroupRoomAsAdmin).mock.calls[0][0];
+        expect(createCall.creatorUserId).toBe("@me:matrix.local");
+        // The partner from the original DM + the newcomer should be invited.
+        expect(createCall.inviteeUserIds).toContain("@partner:matrix.local");
+        expect(createCall.inviteeUserIds).toContain("@newcomer:matrix.local");
+        expect(vi.mocked(postSystemNotice)).toHaveBeenCalled();
+      }));
+
+    it("captures per-agent failures from adminJoinRoom without aborting the batch", () =>
+      withTestTransaction(async (db) => {
+        const user = await createTestAgent(db, {
+          matrixUserId: "@me:matrix.local",
+          matrixAccessToken: "syt_me",
+        });
+        const good = await createTestAgent(db, {
+          matrixUserId: "@good:matrix.local",
+          matrixAccessToken: "syt_good",
+        });
+        const bad = await createTestAgent(db, {
+          matrixUserId: "@bad:matrix.local",
+          matrixAccessToken: "syt_bad",
+        });
+        vi.mocked(auth).mockResolvedValue(mockAuthSession(user.id));
+        vi.mocked(getRoomMembers).mockResolvedValueOnce([
+          "@me:matrix.local",
+          "@a:matrix.local",
+          "@b:matrix.local",
+        ]);
+        vi.mocked(adminJoinRoom).mockImplementation(async (params) => {
+          if (params.userId === "@bad:matrix.local") {
+            throw new Error("kicked-banned");
+          }
+        });
+
+        const result = await addParticipantsToRoom(
+          "!group:matrix.local",
+          [good.id, bad.id],
+        );
+
+        expect(result.added).toEqual([good.id]);
+        expect(result.failed).toEqual([
+          { agentId: bad.id, reason: "kicked-banned" },
+        ]);
+      }));
+
+    it("dedupes the agent list and caps at 50", () =>
+      withTestTransaction(async (db) => {
+        const user = await createTestAgent(db, {
+          matrixUserId: "@me:matrix.local",
+          matrixAccessToken: "syt_me",
+        });
+        const target = await createTestAgent(db, {
+          matrixUserId: "@target:matrix.local",
+          matrixAccessToken: "syt_target",
+        });
+        vi.mocked(auth).mockResolvedValue(mockAuthSession(user.id));
+        vi.mocked(getRoomMembers).mockResolvedValueOnce([
+          "@me:matrix.local",
+          "@a:matrix.local",
+          "@b:matrix.local",
+        ]);
+
+        const dupes = [target.id, target.id, target.id];
+        const result = await addParticipantsToRoom("!group:matrix.local", dupes);
+
+        // Even though the input had 3 entries, only one join was attempted.
+        expect(result.added).toEqual([target.id]);
+        expect(vi.mocked(adminJoinRoom)).toHaveBeenCalledTimes(1);
       }));
   });
 });

--- a/src/app/actions/matrix.ts
+++ b/src/app/actions/matrix.ts
@@ -18,11 +18,32 @@
  */
 import { auth } from "@/auth";
 import { db } from "@/db";
-import { agents, resources, ledger, groupMatrixRooms } from "@/db/schema";
-import { eq, and, inArray } from "drizzle-orm";
-import { adminJoinRoom } from "@/lib/matrix-admin";
+import { agents, resources, ledger, groupMatrixRooms, dmRooms } from "@/db/schema";
+import { eq, and, inArray, isNull } from "drizzle-orm";
+import {
+  adminJoinRoom,
+  createGroupRoomAsAdmin,
+  getRoomMembers,
+  postSystemNotice,
+} from "@/lib/matrix-admin";
 import { provisionMatrixUser } from "@/lib/matrix-admin";
+import { MatrixProvisioningError } from "@/lib/matrix-errors";
 
+/**
+ * Ensures an agent has a fully-provisioned Matrix identity, treating null
+ * access tokens as "not provisioned." Returns the agent's Matrix user ID
+ * on success, or null on any failure.
+ *
+ * Behavior:
+ * - If both `matrixUserId` and `matrixAccessToken` are set, returns the user id
+ *   without touching Synapse.
+ * - If either column is null/empty, calls `provisionMatrixUser` (which is
+ *   idempotent on Synapse — re-creating a user is a no-op, re-issuing a token
+ *   always works) and persists BOTH columns atomically in a single UPDATE.
+ *   On any failure, the DB is left untouched, leaving the row marked as
+ *   "not provisioned" so the next call retries cleanly.
+ * - If the agent record doesn't exist, returns null.
+ */
 async function ensureAgentMatrixIdentity(agentId: string): Promise<string | null> {
   const agent = await db.query.agents.findFirst({
     where: eq(agents.id, agentId),
@@ -36,7 +57,25 @@ async function ensureAgentMatrixIdentity(agentId: string): Promise<string | null
   });
 
   if (!agent) return null;
-  if (agent.matrixUserId && agent.matrixAccessToken) return agent.matrixUserId;
+
+  // Treat empty strings the same as null — an empty access token is unusable.
+  const hasValidUserId =
+    typeof agent.matrixUserId === "string" && agent.matrixUserId.length > 0;
+  const hasValidToken =
+    typeof agent.matrixAccessToken === "string" &&
+    agent.matrixAccessToken.length > 0;
+
+  if (hasValidUserId && hasValidToken) return agent.matrixUserId as string;
+
+  // Half-provisioned state (userId set, token missing) is recoverable because
+  // Synapse PUT is idempotent and `/login` can re-issue tokens for existing
+  // users. Log it explicitly so we can spot recurring drift in monitoring.
+  if (hasValidUserId && !hasValidToken) {
+    console.warn(
+      "[matrix] Agent has matrixUserId but null/empty matrixAccessToken; re-provisioning:",
+      agentId,
+    );
+  }
 
   try {
     const localpart = agent.id.replace(/-/g, "");
@@ -45,17 +84,56 @@ async function ensureAgentMatrixIdentity(agentId: string): Promise<string | null
       displayName: agent.name,
     });
 
-    await db
-      .update(agents)
-      .set({
-        matrixUserId: result.matrixUserId,
-        matrixAccessToken: result.accessToken,
-      })
-      .where(eq(agents.id, agent.id));
+    // Atomic write — both columns set together so callers can rely on the
+    // invariant: matrixAccessToken non-null implies matrixUserId non-null.
+    // If this UPDATE fails (very rare; only catastrophic DB faults), we
+    // explicitly clear any stale row so a future retry can re-provision
+    // cleanly without leaving a half-state behind.
+    try {
+      await db
+        .update(agents)
+        .set({
+          matrixUserId: result.matrixUserId,
+          matrixAccessToken: result.accessToken,
+        })
+        .where(eq(agents.id, agent.id));
+    } catch (dbError) {
+      console.error(
+        "[matrix] DB write of new Matrix credentials failed; clearing partial state for agent:",
+        agentId,
+        dbError,
+      );
+      // Best-effort rollback. If this also fails, the row is stale but a
+      // subsequent ensureAgentMatrixIdentity call will treat null token as
+      // not-provisioned and retry — so we don't bubble this cascade error.
+      await db
+        .update(agents)
+        .set({ matrixUserId: null, matrixAccessToken: null })
+        .where(eq(agents.id, agent.id))
+        .catch((rollbackError) => {
+          console.error(
+            "[matrix] Rollback of partial Matrix state also failed for agent:",
+            agentId,
+            rollbackError,
+          );
+        });
+      return null;
+    }
 
     return result.matrixUserId;
   } catch (error) {
-    console.error("[matrix] Failed to provision Matrix identity for agent:", agentId, error);
+    if (error instanceof MatrixProvisioningError) {
+      console.error(
+        `[matrix] Provisioning stage=${error.stage} failed for agent ${agentId}:`,
+        error.message,
+      );
+    } else {
+      console.error(
+        "[matrix] Unexpected provisioning error for agent:",
+        agentId,
+        error,
+      );
+    }
     return null;
   }
 }
@@ -183,6 +261,316 @@ export async function ensureUserJoinedRoom(
   }
 }
 
+// ─── dmRooms mirror ────────────────────────────────────────────────────────
+
+/**
+ * Records a DM (1:1 or group) into the RIVR-side `dm_rooms` mirror table.
+ *
+ * Called by `getOrCreateDmRoom`/`createGroupDmRoom` (client-side) right
+ * after Synapse confirms the new room. The mirror is keyed by
+ * `matrixRoomId` so reposting an existing pairing is a no-op — we only
+ * insert when the row doesn't already exist for that room (and is not
+ * tombstoned). Failures are logged but never propagated to the caller;
+ * a missing mirror row is recoverable via reconcile.
+ *
+ * @param matrixRoomId - The Matrix room ID (must start with `!`)
+ * @param participantAgentIds - RIVR agent IDs of all participants
+ *   including the caller. Stored in the row so a homeserver migration
+ *   can rebuild the room with the same participants.
+ */
+export async function recordDmRoomMirror(
+  matrixRoomId: string,
+  participantAgentIds: string[],
+): Promise<void> {
+  const session = await auth();
+  if (!session?.user?.id) return;
+
+  if (!matrixRoomId.startsWith("!")) {
+    console.error("[matrix] recordDmRoomMirror: invalid roomId:", matrixRoomId);
+    return;
+  }
+
+  // Dedupe + ensure the caller is always in the participants list so the
+  // mirror is internally consistent even if the client forgot to include
+  // themselves.
+  const participants = Array.from(
+    new Set([session.user.id, ...participantAgentIds.filter(Boolean)]),
+  );
+
+  try {
+    const existing = await db.query.dmRooms.findFirst({
+      where: and(eq(dmRooms.matrixRoomId, matrixRoomId), isNull(dmRooms.deletedAt)),
+      columns: { id: true },
+    });
+
+    if (existing) {
+      // Refresh updatedAt + participants in case the membership grew.
+      await db
+        .update(dmRooms)
+        .set({ participants, updatedAt: new Date() })
+        .where(eq(dmRooms.id, existing.id));
+      return;
+    }
+
+    await db.insert(dmRooms).values({
+      matrixRoomId,
+      participants,
+    });
+  } catch (err) {
+    // Don't surface to the caller — mirror is recoverable via reconcile.
+    console.error(
+      `[matrix] recordDmRoomMirror failed for ${matrixRoomId}:`,
+      err,
+    );
+  }
+}
+
+// ─── Add-to-chat & DM→Group promotion ──────────────────────────────────────
+
+/**
+ * Per-agent outcome for `addParticipantsToRoom`. Failures carry a reason
+ * string so the UI can show "could not add @X: not provisioned" instead of
+ * silently dropping the agent.
+ */
+export interface AddParticipantsFailure {
+  agentId: string;
+  reason: string;
+}
+
+/**
+ * Result of `addParticipantsToRoom`. If the original room was a 1:1 DM and
+ * new participants were added, `promotedToRoomId` carries the new group
+ * room ID so the client can navigate. Otherwise it's null and the new
+ * participants joined the original room.
+ */
+export interface AddParticipantsResult {
+  /** Agent IDs that were successfully invited/joined */
+  added: string[];
+  /** Per-agent failures with reasons */
+  failed: AddParticipantsFailure[];
+  /** New group room ID when a 1:1 DM was promoted; null otherwise */
+  promotedToRoomId: string | null;
+}
+
+/** Maximum number of new participants accepted in one call (prevents abuse). */
+const MAX_PARTICIPANTS_PER_CALL = 50;
+
+/**
+ * Adds one or more agents to an existing Matrix room. For each agent we:
+ *   1. Ensure the agent has a Matrix identity (provisioning if needed).
+ *   2. Force-join them into the target room via the Synapse admin API
+ *      (`/_synapse/admin/v1/join/{roomId}`), which both invites and accepts
+ *      so the room appears immediately without manual confirmation.
+ *
+ * If the target room is a 1:1 DM (exactly 2 current members) and at least
+ * one new agent is being added, the room is promoted to a fresh group room:
+ *   - A new room is created with the original 2 members + new participants.
+ *   - A system notice is posted in the new room.
+ *   - The new room ID is returned via `promotedToRoomId` for client-side
+ *     navigation. The original DM is left untouched (clients can leave it
+ *     via the existing leave path if desired).
+ *
+ * @param roomId - Existing Matrix room ID (must start with `!`)
+ * @param agentIds - RIVR agent IDs (UUIDs) to add as participants
+ * @returns Result with per-agent success/failure and optional promotion target
+ */
+export async function addParticipantsToRoom(
+  roomId: string,
+  agentIds: string[],
+): Promise<AddParticipantsResult> {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return {
+      added: [],
+      failed: agentIds.map((agentId) => ({
+        agentId,
+        reason: "Not authenticated",
+      })),
+      promotedToRoomId: null,
+    };
+  }
+
+  if (!roomId.startsWith("!")) {
+    return {
+      added: [],
+      failed: agentIds.map((agentId) => ({
+        agentId,
+        reason: "Invalid roomId: must start with !",
+      })),
+      promotedToRoomId: null,
+    };
+  }
+
+  // Dedupe + cap to keep things bounded.
+  const uniqueAgentIds = Array.from(new Set(agentIds.filter(Boolean))).slice(
+    0,
+    MAX_PARTICIPANTS_PER_CALL,
+  );
+
+  if (uniqueAgentIds.length === 0) {
+    return { added: [], failed: [], promotedToRoomId: null };
+  }
+
+  // Ensure all target agents have Matrix identities first. Provisioning is
+  // serialized inside ensureAgentMatrixIdentity but we run the lookups in
+  // parallel here.
+  const resolved = await Promise.all(
+    uniqueAgentIds.map(async (agentId) => {
+      try {
+        const matrixUserId = await ensureAgentMatrixIdentity(agentId);
+        return { agentId, matrixUserId };
+      } catch (err) {
+        return {
+          agentId,
+          matrixUserId: null as string | null,
+          reason: err instanceof Error ? err.message : String(err),
+        };
+      }
+    }),
+  );
+
+  const failed: AddParticipantsFailure[] = [];
+  const targetsToInvite: { agentId: string; matrixUserId: string }[] = [];
+  for (const entry of resolved) {
+    if (!entry.matrixUserId) {
+      failed.push({
+        agentId: entry.agentId,
+        reason:
+          ("reason" in entry && typeof entry.reason === "string"
+            ? entry.reason
+            : null) ?? "Could not provision Matrix identity",
+      });
+      continue;
+    }
+    targetsToInvite.push({
+      agentId: entry.agentId,
+      matrixUserId: entry.matrixUserId,
+    });
+  }
+
+  if (targetsToInvite.length === 0) {
+    return { added: [], failed, promotedToRoomId: null };
+  }
+
+  // Detect whether this is a 1:1 DM we should promote. Failure to read the
+  // member list (e.g. transient Synapse hiccup) falls back to a plain
+  // invite to preserve the user's intent.
+  let currentMembers: string[] = [];
+  try {
+    currentMembers = await getRoomMembers(roomId);
+  } catch (err) {
+    console.warn(
+      `[matrix] addParticipantsToRoom: getRoomMembers failed for ${roomId}; treating as non-DM:`,
+      err,
+    );
+    currentMembers = [];
+  }
+
+  const isOneToOneDm = currentMembers.length === 2;
+  const callerAgent = await db.query.agents.findFirst({
+    where: eq(agents.id, session.user.id),
+    columns: { matrixUserId: true },
+  });
+  const callerMatrixUserId = callerAgent?.matrixUserId ?? null;
+
+  if (isOneToOneDm && targetsToInvite.length > 0 && callerMatrixUserId) {
+    // Promote the DM to a fresh group room with all members.
+    const allInvitees = Array.from(
+      new Set([
+        ...currentMembers.filter((m) => m !== callerMatrixUserId),
+        ...targetsToInvite.map((t) => t.matrixUserId),
+      ]),
+    );
+
+    try {
+      const { roomId: newRoomId } = await createGroupRoomAsAdmin({
+        creatorUserId: callerMatrixUserId,
+        inviteeUserIds: allInvitees,
+      });
+
+      // Force-join every invitee so they see the room without manually
+      // accepting. Best-effort: any individual failure shows up in `failed`.
+      const added: string[] = [];
+      for (const target of targetsToInvite) {
+        try {
+          await adminJoinRoom({
+            userId: target.matrixUserId,
+            roomId: newRoomId,
+          });
+          added.push(target.agentId);
+        } catch (err) {
+          failed.push({
+            agentId: target.agentId,
+            reason: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+
+      // Also force-join the original other-party (the previous DM partner)
+      // so the new room has continuity for them.
+      for (const memberId of currentMembers) {
+        if (memberId === callerMatrixUserId) continue;
+        try {
+          await adminJoinRoom({ userId: memberId, roomId: newRoomId });
+        } catch (err) {
+          console.error(
+            `[matrix] promotion: failed to force-join prior DM partner ${memberId}:`,
+            err,
+          );
+        }
+      }
+
+      // Post a system notice marking the upgrade. Non-blocking — if it
+      // fails the promotion still succeeded.
+      try {
+        await postSystemNotice({
+          senderUserId: callerMatrixUserId,
+          roomId: newRoomId,
+          body: "Conversation upgraded to group chat",
+        });
+      } catch (err) {
+        console.error("[matrix] promotion: postSystemNotice failed:", err);
+      }
+
+      // Mirror the new group DM row so the room survives a homeserver
+      // migration. Failure to mirror doesn't affect the promotion success.
+      try {
+        await recordDmRoomMirror(newRoomId, [
+          session.user.id,
+          ...targetsToInvite.map((t) => t.agentId),
+        ]);
+      } catch (err) {
+        console.error("[matrix] promotion: recordDmRoomMirror failed:", err);
+      }
+
+      return { added, failed, promotedToRoomId: newRoomId };
+    } catch (err) {
+      // Promotion failed — fall through to the plain-invite path so the
+      // user still gets *some* effect rather than a silent error.
+      console.error(
+        `[matrix] addParticipantsToRoom: promotion failed for ${roomId}; falling back to direct invite:`,
+        err,
+      );
+    }
+  }
+
+  // Non-DM (or promotion fallback): force-join everyone into the existing room.
+  const added: string[] = [];
+  for (const target of targetsToInvite) {
+    try {
+      await adminJoinRoom({ userId: target.matrixUserId, roomId });
+      added.push(target.agentId);
+    } catch (err) {
+      failed.push({
+        agentId: target.agentId,
+        reason: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return { added, failed, promotedToRoomId: null };
+}
+
 /**
  * Resolves a marketplace listing to its owner's Matrix user ID.
  *
@@ -265,6 +653,8 @@ export async function getUserGroupRooms(): Promise<
     .where(inArray(agents.id, groupIds));
 
   // 3. Fetch Matrix room mappings for these groups
+  // Soft-deleted rows (deletedAt IS NOT NULL) are excluded so we don't surface
+  // rooms whose underlying Synapse room has been purged.
   const matrixRooms = await db
     .select({
       groupAgentId: groupMatrixRooms.groupAgentId,
@@ -272,7 +662,12 @@ export async function getUserGroupRooms(): Promise<
       chatMode: groupMatrixRooms.chatMode,
     })
     .from(groupMatrixRooms)
-    .where(inArray(groupMatrixRooms.groupAgentId, groupIds));
+    .where(
+      and(
+        inArray(groupMatrixRooms.groupAgentId, groupIds),
+        isNull(groupMatrixRooms.deletedAt),
+      ),
+    );
 
   const roomsByGroupId = new Map(
     matrixRooms.map((r) => [r.groupAgentId, r])
@@ -298,7 +693,12 @@ export async function getUserGroupRooms(): Promise<
             matrixRoomId: groupMatrixRooms.matrixRoomId,
           })
           .from(groupMatrixRooms)
-          .where(inArray(groupMatrixRooms.groupAgentId, subgroupIds))
+          .where(
+            and(
+              inArray(groupMatrixRooms.groupAgentId, subgroupIds),
+              isNull(groupMatrixRooms.deletedAt),
+            ),
+          )
       : [];
 
   const subgroupRoomMap = new Map(

--- a/src/app/api/admin/matrix/reconcile/route.ts
+++ b/src/app/api/admin/matrix/reconcile/route.ts
@@ -1,0 +1,91 @@
+/**
+ * Admin endpoint to reconcile orphaned Matrix room mappings.
+ *
+ * Walks every live row in `group_matrix_rooms` (and `dmRooms`), probes Synapse
+ * for the underlying room, and soft-deletes rows whose rooms have been purged.
+ * Synapse errors that aren't 404 are surfaced in the response so an operator
+ * can decide whether to retry; the rows themselves are left alive.
+ *
+ * Auth: gated by `metadata.siteRole === "admin"` on the calling agent, the same
+ * pattern used by `apps/global/src/app/api/admin/smtp-config/route.ts`.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { auth } from "@/auth";
+import { db } from "@/db";
+import { agents } from "@/db/schema";
+import {
+  STATUS_FORBIDDEN,
+  STATUS_INTERNAL_ERROR,
+  STATUS_OK,
+  STATUS_UNAUTHORIZED,
+} from "@/lib/http-status";
+import { reconcileGroupMatrixRooms, reconcileDmRooms } from "@/lib/matrix-groups";
+
+const ADMIN_FORBIDDEN_MESSAGE = "Forbidden: admin privileges required";
+const UNAUTHORIZED_MESSAGE = "Authentication required";
+
+async function requireAdminOrRespond(): Promise<NextResponse | null> {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json(
+      { error: UNAUTHORIZED_MESSAGE },
+      { status: STATUS_UNAUTHORIZED },
+    );
+  }
+
+  const [agent] = await db
+    .select({ metadata: agents.metadata })
+    .from(agents)
+    .where(eq(agents.id, session.user.id))
+    .limit(1);
+
+  const metadata =
+    agent?.metadata && typeof agent.metadata === "object" && !Array.isArray(agent.metadata)
+      ? (agent.metadata as Record<string, unknown>)
+      : {};
+
+  if (metadata.siteRole !== "admin") {
+    return NextResponse.json(
+      { error: ADMIN_FORBIDDEN_MESSAGE },
+      { status: STATUS_FORBIDDEN },
+    );
+  }
+
+  return null;
+}
+
+/**
+ * POST /api/admin/matrix/reconcile
+ *
+ * Body: none (request body is ignored).
+ * Returns: `{ ok: true, groups: {...}, dms: {...} }` on success.
+ */
+export async function POST(_request: NextRequest): Promise<NextResponse> {
+  void _request;
+
+  const denied = await requireAdminOrRespond();
+  if (denied) return denied;
+
+  try {
+    const groups = await reconcileGroupMatrixRooms();
+    const dms = await reconcileDmRooms();
+
+    return NextResponse.json(
+      {
+        ok: true,
+        groups,
+        dms,
+      },
+      { status: STATUS_OK },
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`[admin/matrix/reconcile] failed: ${message}`);
+    return NextResponse.json(
+      { ok: false, error: "Reconciliation failed", detail: message },
+      { status: STATUS_INTERNAL_ERROR },
+    );
+  }
+}

--- a/src/components/chat/add-to-chat-dialog.tsx
+++ b/src/components/chat/add-to-chat-dialog.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+/**
+ * Add to Chat dialog — searches the social graph, multi-selects agents,
+ * and adds them to an existing Matrix room via `addParticipantsToRoom`.
+ *
+ * Reused by both `MatrixChatPanel` (DM rooms; triggers 1:1→group promotion
+ * when 2-member rooms gain participants) and `GroupChatPanel` (group rooms;
+ * just force-joins new members).
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Search, X } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { searchAgentsByName } from "@/app/actions/graph";
+import type { SerializedAgent } from "@/lib/graph-serializers";
+
+const DEBOUNCE_MS = 300;
+const SEARCH_LIMIT = 15;
+
+interface SelectedAgent {
+  id: string;
+  name: string;
+  image: string | null;
+}
+
+interface AddToChatDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Called with the selected agent IDs when the user clicks Add. */
+  onAdd: (agentIds: string[]) => Promise<void> | void;
+  /** Whether the parent is currently processing an add (disables the button). */
+  isAdding?: boolean;
+}
+
+function initials(name: string) {
+  return name
+    .split(" ")
+    .map((part) => part[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+}
+
+export function AddToChatDialog({
+  open,
+  onOpenChange,
+  onAdd,
+  isAdding,
+}: AddToChatDialogProps) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<SerializedAgent[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [selected, setSelected] = useState<SelectedAgent[]>([]);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const search = useCallback(async (term: string) => {
+    if (term.trim().length < 2) {
+      setResults([]);
+      setSearching(false);
+      return;
+    }
+
+    setSearching(true);
+    try {
+      const agents = await searchAgentsByName(term.trim(), SEARCH_LIMIT);
+      setResults(agents);
+    } catch (err) {
+      console.error("[add-to-chat] search failed:", err);
+      setResults([]);
+    } finally {
+      setSearching(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+
+    if (query.trim().length < 2) {
+      setResults([]);
+      return;
+    }
+
+    debounceRef.current = setTimeout(() => {
+      void search(query);
+    }, DEBOUNCE_MS);
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [query, search]);
+
+  useEffect(() => {
+    if (!open) {
+      setQuery("");
+      setResults([]);
+      setSearching(false);
+      setSelected([]);
+    }
+  }, [open]);
+
+  const handleToggle = (agent: SerializedAgent) => {
+    setSelected((prev) => {
+      const exists = prev.find((u) => u.id === agent.id);
+      if (exists) return prev.filter((u) => u.id !== agent.id);
+      return [...prev, { id: agent.id, name: agent.name, image: agent.image }];
+    });
+    setQuery("");
+    setResults([]);
+    setTimeout(() => inputRef.current?.focus(), 0);
+  };
+
+  const handleRemove = (id: string) => {
+    setSelected((prev) => prev.filter((u) => u.id !== id));
+  };
+
+  const handleSubmit = async () => {
+    if (selected.length === 0 || isAdding) return;
+    const ids = selected.map((u) => u.id);
+    await onAdd(ids);
+  };
+
+  const selectedIds = new Set(selected.map((u) => u.id));
+  const filtered = results.filter((a) => !selectedIds.has(a.id));
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Add to chat</DialogTitle>
+          <DialogDescription>
+            Search for people to bring into this conversation. Adding to a
+            1-on-1 chat upgrades it to a group chat.
+          </DialogDescription>
+        </DialogHeader>
+
+        {selected.length > 0 && (
+          <div className="flex flex-wrap gap-2">
+            {selected.map((user) => (
+              <div
+                key={user.id}
+                className="flex items-center gap-1.5 bg-muted rounded-full pl-1 pr-2 py-1"
+              >
+                <Avatar className="h-6 w-6">
+                  <AvatarImage src={user.image ?? undefined} alt={user.name} />
+                  <AvatarFallback className="text-xs">
+                    {initials(user.name)}
+                  </AvatarFallback>
+                </Avatar>
+                <span className="text-sm font-medium truncate max-w-[120px]">
+                  {user.name}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => handleRemove(user.id)}
+                  className="ml-0.5 rounded-full p-0.5 hover:bg-muted-foreground/20 transition-colors"
+                  aria-label={`Remove ${user.name}`}
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div className="relative">
+          <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+          <Input
+            ref={inputRef}
+            type="search"
+            placeholder="Search by name..."
+            className="pl-10"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            autoFocus
+          />
+        </div>
+
+        <div className="max-h-60 overflow-y-auto -mx-2">
+          {searching && (
+            <p className="text-center text-sm text-muted-foreground py-4">
+              Searching...
+            </p>
+          )}
+
+          {!searching && query.trim().length >= 2 && filtered.length === 0 && (
+            <p className="text-center text-sm text-muted-foreground py-4">
+              No matches
+            </p>
+          )}
+
+          {filtered.map((agent) => {
+            const metadata = (agent.metadata ?? {}) as Record<string, unknown>;
+            const username =
+              typeof metadata.username === "string" ? metadata.username : "";
+            return (
+              <button
+                key={agent.id}
+                type="button"
+                className="w-full text-left flex items-center gap-3 px-2 py-3 rounded-md hover:bg-muted/50 transition-colors"
+                onClick={() => handleToggle(agent)}
+              >
+                <Avatar className="h-10 w-10">
+                  <AvatarImage src={agent.image ?? undefined} alt={agent.name} />
+                  <AvatarFallback>{initials(agent.name)}</AvatarFallback>
+                </Avatar>
+                <div className="min-w-0 flex-1">
+                  <p className="font-medium truncate">{agent.name}</p>
+                  {username && (
+                    <p className="text-sm text-muted-foreground truncate">
+                      @{username}
+                    </p>
+                  )}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+
+        <Button
+          onClick={() => void handleSubmit()}
+          disabled={selected.length === 0 || isAdding}
+          className="w-full"
+        >
+          {isAdding
+            ? "Adding..."
+            : selected.length === 0
+              ? "Add"
+              : `Add ${selected.length} ${selected.length === 1 ? "person" : "people"}`}
+        </Button>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/chat/group-chat-panel.tsx
+++ b/src/components/chat/group-chat-panel.tsx
@@ -33,6 +33,8 @@ interface GroupChatPanelProps {
   ledgerFeedContent?: React.ReactNode;
   /** Callback when back button is pressed */
   onBack?: () => void;
+  /** Forwarded to MatrixChatPanel so the parent can react to add-to-chat events. */
+  onParticipantsAdded?: (result: { promotedRoomId: string | null }) => void;
 }
 
 type ActiveTab = "chat" | "feed";
@@ -46,6 +48,7 @@ export function GroupChatPanel({
   currentUserId,
   ledgerFeedContent,
   onBack,
+  onParticipantsAdded,
 }: GroupChatPanelProps) {
   const [activeTab, setActiveTab] = useState<ActiveTab>("chat");
 
@@ -88,6 +91,7 @@ export function GroupChatPanel({
         roomName={groupName}
         roomAvatarUrl={groupAvatarUrl}
         onBack={onBack}
+        onParticipantsAdded={onParticipantsAdded}
       />
     );
   }

--- a/src/components/chat/matrix-chat-panel.tsx
+++ b/src/components/chat/matrix-chat-panel.tsx
@@ -8,11 +8,14 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { ArrowLeft, Send } from "lucide-react";
+import { ArrowLeft, Send, UserPlus } from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { MessageBubble } from "./message-bubble";
+import { AddToChatDialog } from "./add-to-chat-dialog";
+import { addParticipantsToRoom } from "@/app/actions/matrix";
+import { toast } from "@/components/ui/use-toast";
 import { MsgType, RoomEvent } from "matrix-js-sdk";
 import type { MatrixClient, MatrixEvent, Room } from "matrix-js-sdk";
 
@@ -31,6 +34,12 @@ interface MatrixChatPanelProps {
   roomName: string;
   roomAvatarUrl?: string | null;
   onBack?: () => void;
+  /**
+   * Called after `addParticipantsToRoom` returns. When the call promoted a
+   * 1:1 DM to a new group room, `promotedRoomId` is the new room ID and the
+   * parent should navigate the chat panel to it.
+   */
+  onParticipantsAdded?: (result: { promotedRoomId: string | null }) => void;
 }
 
 function initials(name: string) {
@@ -49,11 +58,66 @@ export function MatrixChatPanel({
   roomName,
   roomAvatarUrl,
   onBack,
+  onParticipantsAdded,
 }: MatrixChatPanelProps) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [messageText, setMessageText] = useState("");
   const [sending, setSending] = useState(false);
+  const [addOpen, setAddOpen] = useState(false);
+  const [addingParticipants, setAddingParticipants] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  const handleAddParticipants = useCallback(
+    async (agentIds: string[]) => {
+      if (agentIds.length === 0) return;
+      setAddingParticipants(true);
+      try {
+        const result = await addParticipantsToRoom(roomId, agentIds);
+        const addedCount = result.added.length;
+        const failedCount = result.failed.length;
+
+        if (result.promotedToRoomId) {
+          toast({
+            title: "Conversation upgraded to group chat",
+            description: `${addedCount} ${addedCount === 1 ? "person" : "people"} added.`,
+          });
+          onParticipantsAdded?.({ promotedRoomId: result.promotedToRoomId });
+        } else if (addedCount > 0) {
+          toast({
+            title: `Added ${addedCount} to chat`,
+            description:
+              failedCount > 0
+                ? `${failedCount} could not be added: ${result.failed
+                    .map((f) => f.reason)
+                    .join("; ")}`
+                : undefined,
+          });
+          onParticipantsAdded?.({ promotedRoomId: null });
+        } else {
+          toast({
+            title: "Could not add participants",
+            description:
+              result.failed.length > 0
+                ? result.failed.map((f) => f.reason).join("; ")
+                : "Unknown failure.",
+            variant: "destructive",
+          });
+        }
+
+        setAddOpen(false);
+      } catch (err) {
+        console.error("[matrix-chat] addParticipantsToRoom failed:", err);
+        toast({
+          title: "Could not add participants",
+          description: err instanceof Error ? err.message : String(err),
+          variant: "destructive",
+        });
+      } finally {
+        setAddingParticipants(false);
+      }
+    },
+    [roomId, onParticipantsAdded],
+  );
 
   // Load existing timeline from the room
   const loadTimeline = useCallback(() => {
@@ -167,11 +231,28 @@ export function MatrixChatPanel({
           <AvatarFallback>{initials(roomName)}</AvatarFallback>
         </Avatar>
 
-        <div>
-          <p className="font-medium">{roomName}</p>
+        <div className="flex-1 min-w-0">
+          <p className="font-medium truncate">{roomName}</p>
           <p className="text-xs text-muted-foreground">Direct messages</p>
         </div>
+
+        <Button
+          variant="ghost"
+          size="icon"
+          className="ml-auto"
+          aria-label="Add to chat"
+          onClick={() => setAddOpen(true)}
+        >
+          <UserPlus className="h-5 w-5" />
+        </Button>
       </div>
+
+      <AddToChatDialog
+        open={addOpen}
+        onOpenChange={setAddOpen}
+        onAdd={handleAddParticipants}
+        isAdding={addingParticipants}
+      />
 
       {/* Messages */}
       <div className="flex-1 overflow-y-auto p-4 space-y-4">

--- a/src/db/migrations/0049_group_matrix_rooms_soft_delete.sql
+++ b/src/db/migrations/0049_group_matrix_rooms_soft_delete.sql
@@ -1,0 +1,14 @@
+-- Soft-delete column for groupMatrixRooms so we can reconcile rows whose
+-- Synapse-side rooms have been purged without losing the historical mapping.
+ALTER TABLE "group_matrix_rooms" ADD COLUMN IF NOT EXISTS "deleted_at" timestamp with time zone;--> statement-breakpoint
+
+DROP INDEX IF EXISTS "group_matrix_rooms_group_agent_id_idx";--> statement-breakpoint
+DROP INDEX IF EXISTS "group_matrix_rooms_matrix_room_id_idx";--> statement-breakpoint
+
+CREATE UNIQUE INDEX IF NOT EXISTS "group_matrix_rooms_group_agent_id_idx"
+  ON "group_matrix_rooms" ("group_agent_id")
+  WHERE "deleted_at" IS NULL;--> statement-breakpoint
+
+CREATE UNIQUE INDEX IF NOT EXISTS "group_matrix_rooms_matrix_room_id_idx"
+  ON "group_matrix_rooms" ("matrix_room_id")
+  WHERE "deleted_at" IS NULL;

--- a/src/db/migrations/0050_dm_rooms_mirror.sql
+++ b/src/db/migrations/0050_dm_rooms_mirror.sql
@@ -1,0 +1,14 @@
+-- RIVR-side mirror for Matrix DM rooms so the (matrixRoomId, participants)
+-- tuple survives a homeserver migration and degraded sync.
+CREATE TABLE IF NOT EXISTS "dm_rooms" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "matrix_room_id" text NOT NULL,
+  "participants" jsonb DEFAULT '[]'::jsonb NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "deleted_at" timestamp with time zone
+);--> statement-breakpoint
+
+CREATE UNIQUE INDEX IF NOT EXISTS "dm_rooms_matrix_room_id_idx"
+  ON "dm_rooms" ("matrix_room_id")
+  WHERE "deleted_at" IS NULL;

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -204,6 +204,27 @@
       "when": 1777118400000,
       "tag": "0043_peer_smtp_config",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1778198400000,
+      "tag": "0048_federation_entity_map_relationship",
+      "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1778832000000,
+      "tag": "0049_group_matrix_rooms_soft_delete",
+      "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "7",
+      "when": 1778832060000,
+      "tag": "0050_dm_rooms_mirror",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1411,10 +1411,19 @@ export const groupMatrixRooms = pgTable(
     chatMode: chatModeEnum('chat_mode').notNull().default('both'),
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+    // Soft-delete marker: set when the underlying Synapse room is purged so we
+    // can keep the historical mapping without blocking creation of a new room.
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
   },
   (table) => [
-    uniqueIndex('group_matrix_rooms_group_agent_id_idx').on(table.groupAgentId),
-    uniqueIndex('group_matrix_rooms_matrix_room_id_idx').on(table.matrixRoomId),
+    // Partial unique indexes keep one live row per group and per matrix room,
+    // while tombstoned rows are exempt from the constraint.
+    uniqueIndex('group_matrix_rooms_group_agent_id_idx')
+      .on(table.groupAgentId)
+      .where(sql`${table.deletedAt} IS NULL`),
+    uniqueIndex('group_matrix_rooms_matrix_room_id_idx')
+      .on(table.matrixRoomId)
+      .where(sql`${table.deletedAt} IS NULL`),
   ]
 );
 
@@ -1424,6 +1433,33 @@ export const groupMatrixRoomsRelations = relations(groupMatrixRooms, ({ one }) =
     references: [agents.id],
   }),
 }));
+
+/**
+ * RIVR-side mirror for Matrix DM rooms (1:1 and group DMs).
+ *
+ * Survives a homeserver migration by preserving the (matrixRoomId,
+ * participants) tuple so the UI can fall back to this list when Matrix
+ * sync is degraded and rebuild the m.direct mapping after re-host.
+ */
+export const dmRooms = pgTable(
+  'dm_rooms',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    matrixRoomId: text('matrix_room_id').notNull(),
+    participants: jsonb('participants').$type<string[]>().notNull().default([]),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  },
+  (table) => [
+    uniqueIndex('dm_rooms_matrix_room_id_idx')
+      .on(table.matrixRoomId)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ]
+);
+
+export type DmRoom = typeof dmRooms.$inferSelect;
+export type NewDmRoom = typeof dmRooms.$inferInsert;
 
 /**
  * Contract action shape stored in the actions JSONB array.

--- a/src/instrumentation-node.ts
+++ b/src/instrumentation-node.ts
@@ -1,0 +1,17 @@
+/**
+ * Node-only side of the instrumentation hook. Runs at server start in the
+ * Node.js runtime ONLY — never compiled for Edge runtime because instrumentation.ts
+ * only imports this file inside a `NEXT_RUNTIME === "nodejs"` guard.
+ *
+ * Side-effect import: kicks off env validation + background matrix reconcile.
+ */
+import { validateEnv } from "@/lib/env";
+import { triggerStartupReconcileGroupMatrixRooms } from "@/lib/matrix-startup";
+
+validateEnv();
+
+try {
+  triggerStartupReconcileGroupMatrixRooms();
+} catch (err) {
+  console.error("[instrumentation] failed to schedule matrix reconcile:", err);
+}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,16 +1,14 @@
 /**
  * Next.js instrumentation hook — runs once when the server starts.
- * Used to validate required environment variables before any request
- * is handled.
  *
- * Uses dynamic import because env.ts depends on Node.js `fs` module,
- * which is unavailable during the webpack edge bundling phase.
+ * The Node-only work lives in `instrumentation-node.ts`. We dynamic-import it
+ * inside a `NEXT_RUNTIME === "nodejs"` guard so Edge runtime never tries to
+ * bundle `postgres`, `fs`, etc.
  *
  * @see https://nextjs.org/docs/app/building-your-application/optimizing/instrumentation
  */
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
-    const { validateEnv } = await import("@/lib/env");
-    validateEnv();
+    await import("./instrumentation-node");
   }
 }

--- a/src/lib/__tests__/matrix-admin.test.ts
+++ b/src/lib/__tests__/matrix-admin.test.ts
@@ -26,6 +26,7 @@ const {
   updateMatrixProfile,
   createDirectMessageRoom,
 } = await import("@/lib/matrix-admin");
+const { MatrixProvisioningError } = await import("@/lib/matrix-errors");
 
 describe("matrix-admin", () => {
   beforeEach(() => {
@@ -77,19 +78,104 @@ describe("matrix-admin", () => {
       expect(loginOpts.method).toBe("POST");
     });
 
-    it("throws on Synapse API failure", async () => {
+    it("throws MatrixProvisioningError with stage=user_create on PUT failure", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: false,
         status: 500,
         json: () => Promise.resolve({ errcode: "M_UNKNOWN" }),
       });
 
-      await expect(
-        provisionMatrixUser({
+      let caught: unknown = null;
+      try {
+        await provisionMatrixUser({
           localpart: "fail_user",
           displayName: "Fail",
-        })
-      ).rejects.toThrow("Synapse admin API error: 500");
+        });
+      } catch (err) {
+        caught = err;
+      }
+
+      expect(caught).toBeInstanceOf(MatrixProvisioningError);
+      expect((caught as InstanceType<typeof MatrixProvisioningError>).stage).toBe(
+        "user_create",
+      );
+    });
+
+    it("throws MatrixProvisioningError with stage=user_login when /login fails after PUT succeeds", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        json: () => Promise.resolve({ errcode: "M_LIMIT_EXCEEDED" }),
+      });
+
+      let caught: unknown = null;
+      try {
+        await provisionMatrixUser({
+          localpart: "login_fail",
+          displayName: "LoginFail",
+        });
+      } catch (err) {
+        caught = err;
+      }
+
+      expect(caught).toBeInstanceOf(MatrixProvisioningError);
+      expect((caught as InstanceType<typeof MatrixProvisioningError>).stage).toBe(
+        "user_login",
+      );
+    });
+
+    it("throws MatrixProvisioningError with stage=missing_token when Synapse returns no access_token", async () => {
+      // PUT user succeeds
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+      // Login returns 200 but with no access_token in the body
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ access_token: "" }),
+      });
+
+      let caught: unknown = null;
+      try {
+        await provisionMatrixUser({
+          localpart: "empty_token",
+          displayName: "EmptyToken",
+        });
+      } catch (err) {
+        caught = err;
+      }
+
+      expect(caught).toBeInstanceOf(MatrixProvisioningError);
+      expect((caught as InstanceType<typeof MatrixProvisioningError>).stage).toBe(
+        "missing_token",
+      );
+    });
+
+    it("supports re-provisioning when Synapse user already exists (PUT idempotent)", async () => {
+      // First PUT — Synapse returns 200 (existing user updated)
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+      // Login issues a fresh token even though the user already existed
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({ access_token: "syt_reissued_token_456" }),
+      });
+
+      const result = await provisionMatrixUser({
+        localpart: "existing_user",
+        displayName: "Existing User",
+      });
+
+      expect(result.matrixUserId).toBe("@existing_user:test.local");
+      expect(result.accessToken).toBe("syt_reissued_token_456");
     });
   });
 

--- a/src/lib/__tests__/matrix-client.test.ts
+++ b/src/lib/__tests__/matrix-client.test.ts
@@ -43,7 +43,17 @@ const {
   sendMessage,
   getOrCreateDmRoom,
   getDmRooms,
+  persistMDirectWithRetry,
+  MatrixDirectRepairError,
 } = await import("@/lib/matrix-client");
+
+const {
+  onMatrixSyncRepair,
+  clearMatrixSyncRepairListenersForTesting,
+  MATRIX_SYNC_REPAIR_FAILED,
+  MATRIX_SYNC_REPAIR_SUCCEEDED,
+  MATRIX_SYNC_REPAIR_EXHAUSTED,
+} = await import("@/lib/matrix-sync-events");
 
 describe("matrix-client", () => {
   beforeEach(() => {
@@ -170,6 +180,125 @@ describe("matrix-client", () => {
       const rooms = getDmRooms(client);
       expect(rooms).toHaveLength(1);
       expect(rooms[0].roomId).toBe("!dm1:test.local");
+    });
+  });
+
+  describe("persistMDirectWithRetry", () => {
+    beforeEach(() => {
+      clearMatrixSyncRepairListenersForTesting();
+      // Silence backoff delays so tests run fast. setTimeout is invoked with
+      // numeric delays in production; we replace it with an immediate scheduler.
+      vi.spyOn(global, "setTimeout").mockImplementation(((cb: () => void) => {
+        cb();
+        // Cast to satisfy NodeJS.Timeout return type; never inspected by callers.
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      }) as typeof setTimeout);
+    });
+
+    it("succeeds on first attempt without emitting a failure event", async () => {
+      const events: unknown[] = [];
+      onMatrixSyncRepair((evt) => events.push(evt));
+      mockClient.setAccountData.mockResolvedValueOnce(undefined);
+
+      const client = getMatrixClient({
+        homeserverUrl: "https://matrix.test.local",
+        userId: "@user1:test.local",
+        accessToken: "token123",
+      });
+
+      await persistMDirectWithRetry(client, { "@bob:test.local": ["!r1"] });
+
+      expect(mockClient.setAccountData).toHaveBeenCalledTimes(1);
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        type: MATRIX_SYNC_REPAIR_SUCCEEDED,
+        attempt: 1,
+      });
+    });
+
+    it("retries with backoff and reports each failure", async () => {
+      const events: unknown[] = [];
+      onMatrixSyncRepair((evt) => events.push(evt));
+
+      mockClient.setAccountData
+        .mockRejectedValueOnce(new Error("rate limited"))
+        .mockRejectedValueOnce(new Error("timeout"))
+        .mockResolvedValueOnce(undefined);
+
+      const client = getMatrixClient({
+        homeserverUrl: "https://matrix.test.local",
+        userId: "@user1:test.local",
+        accessToken: "token123",
+      });
+
+      await persistMDirectWithRetry(client, { "@bob:test.local": ["!r1"] });
+
+      expect(mockClient.setAccountData).toHaveBeenCalledTimes(3);
+      const failures = events.filter(
+        (e) => (e as { type: string }).type === MATRIX_SYNC_REPAIR_FAILED,
+      );
+      expect(failures).toHaveLength(2);
+      expect(failures[0]).toMatchObject({ attempt: 1, message: "rate limited" });
+      expect(failures[1]).toMatchObject({ attempt: 2, message: "timeout" });
+      const successes = events.filter(
+        (e) => (e as { type: string }).type === MATRIX_SYNC_REPAIR_SUCCEEDED,
+      );
+      expect(successes).toHaveLength(1);
+      expect(successes[0]).toMatchObject({ attempt: 3 });
+    });
+
+    it("throws MatrixDirectRepairError after the bounded retry budget is exhausted", async () => {
+      const events: unknown[] = [];
+      onMatrixSyncRepair((evt) => events.push(evt));
+      mockClient.setAccountData.mockRejectedValue(new Error("synapse down"));
+
+      const client = getMatrixClient({
+        homeserverUrl: "https://matrix.test.local",
+        userId: "@user1:test.local",
+        accessToken: "token123",
+      });
+
+      await expect(
+        persistMDirectWithRetry(client, { "@bob:test.local": ["!r1"] }),
+      ).rejects.toBeInstanceOf(MatrixDirectRepairError);
+
+      // 4 failure events + 1 exhausted event = 5 total
+      const exhausted = events.filter(
+        (e) => (e as { type: string }).type === MATRIX_SYNC_REPAIR_EXHAUSTED,
+      );
+      expect(exhausted).toHaveLength(1);
+      expect(exhausted[0]).toMatchObject({
+        attempts: 4,
+        message: "synapse down",
+      });
+    });
+
+    it("emits MATRIX_SYNC_REPAIR_FAILED with nextRetryMs=null on the last attempt", async () => {
+      const events: unknown[] = [];
+      onMatrixSyncRepair((evt) => events.push(evt));
+      mockClient.setAccountData.mockRejectedValue(new Error("nope"));
+
+      const client = getMatrixClient({
+        homeserverUrl: "https://matrix.test.local",
+        userId: "@user1:test.local",
+        accessToken: "token123",
+      });
+
+      await expect(
+        persistMDirectWithRetry(client, { "@bob:test.local": ["!r1"] }),
+      ).rejects.toBeInstanceOf(MatrixDirectRepairError);
+
+      const failures = events.filter(
+        (e) => (e as { type: string }).type === MATRIX_SYNC_REPAIR_FAILED,
+      ) as Array<{ attempt: number; nextRetryMs: number | null }>;
+      expect(failures).toHaveLength(4);
+      expect(failures[3].attempt).toBe(4);
+      expect(failures[3].nextRetryMs).toBeNull();
+      // Earlier attempts must have a positive backoff delay.
+      for (const f of failures.slice(0, 3)) {
+        expect(f.nextRetryMs).not.toBeNull();
+        expect(f.nextRetryMs as number).toBeGreaterThan(0);
+      }
     });
   });
 

--- a/src/lib/__tests__/matrix-groups.test.ts
+++ b/src/lib/__tests__/matrix-groups.test.ts
@@ -18,6 +18,14 @@ vi.mock("@/lib/env", () => ({
 const mockGroupMatrixRoomsInsert = vi.fn();
 const mockGroupMatrixRoomsUpdate = vi.fn();
 
+// Track the rows returned by db.select() chains so reconcile tests can drive
+// different scenarios. Two holders so dmRooms vs groupMatrixRooms can each
+// have their own scenario queue.
+const mockGroupSelectRows: { rows: unknown[] } = { rows: [] };
+const mockDmSelectRows: { rows: unknown[] } = { rows: [] };
+const mockUpdateWhere = vi.fn();
+const mockUpdateSet = vi.fn(() => ({ where: mockUpdateWhere }));
+
 vi.mock("@/db", () => ({
   db: {
     query: {
@@ -27,6 +35,9 @@ vi.mock("@/db", () => ({
       agents: {
         findFirst: vi.fn(),
       },
+      dmRooms: {
+        findFirst: vi.fn(),
+      },
     },
     insert: vi.fn(() => ({
       values: vi.fn(() => ({
@@ -34,8 +45,17 @@ vi.mock("@/db", () => ({
       })),
     })),
     update: vi.fn(() => ({
-      set: vi.fn(() => ({
-        where: vi.fn(),
+      set: mockUpdateSet,
+    })),
+    // Route select() based on which table is passed to .from(). The test
+    // schema mock tags each table with a `__tableTag` so we can dispatch.
+    select: vi.fn(() => ({
+      from: vi.fn((table: { __tableTag?: string }) => ({
+        where: vi.fn(() => {
+          const tag = table?.__tableTag;
+          if (tag === "dmRooms") return Promise.resolve(mockDmSelectRows.rows);
+          return Promise.resolve(mockGroupSelectRows.rows);
+        }),
       })),
     })),
   },
@@ -45,14 +65,29 @@ vi.mock("@/db/schema", async () => {
   return {
     agents: { id: "id" },
     groupMatrixRooms: {
+      __tableTag: "groupMatrixRooms",
       groupAgentId: "group_agent_id",
+      matrixRoomId: "matrix_room_id",
       id: "id",
+      deletedAt: "deleted_at",
+    },
+    dmRooms: {
+      __tableTag: "dmRooms",
+      id: "id",
+      matrixRoomId: "matrix_room_id",
+      participants: "participants",
+      createdAt: "created_at",
+      updatedAt: "updated_at",
+      deletedAt: "deleted_at",
     },
   };
 });
 
 vi.mock("drizzle-orm", () => ({
-  eq: vi.fn((a, b) => ({ field: a, value: b })),
+  eq: vi.fn((a, b) => ({ op: "eq", field: a, value: b })),
+  and: vi.fn((...conds) => ({ op: "and", conds })),
+  isNull: vi.fn((field) => ({ op: "isNull", field })),
+  sql: vi.fn((strings, ...values) => ({ op: "sql", strings, values })),
 }));
 
 const mockFetch = vi.fn();
@@ -66,6 +101,9 @@ const {
   removeFromGroupRoom,
   setGroupChatMode,
   getGroupMatrixRoom,
+  reconcileGroupMatrixRooms,
+  reconcileDmRooms,
+  triggerStartupReconcileGroupMatrixRooms,
 } = await import("@/lib/matrix-groups");
 
 describe("matrix-groups", () => {
@@ -251,6 +289,214 @@ describe("matrix-groups", () => {
       const [url, opts] = mockFetch.mock.calls[0];
       expect(url).toContain("/kick");
       expect(JSON.parse(opts.body).user_id).toBe("@kicked:test.local");
+    });
+  });
+
+  describe("reconcileGroupMatrixRooms", () => {
+    beforeEach(() => {
+      mockGroupSelectRows.rows = [];
+      mockDmSelectRows.rows = [];
+      mockUpdateWhere.mockReset();
+      mockUpdateSet.mockClear();
+    });
+
+    it("returns zero counts when no rows exist", async () => {
+      mockGroupSelectRows.rows = [];
+
+      const result = await reconcileGroupMatrixRooms();
+
+      expect(result.total).toBe(0);
+      expect(result.alive).toBe(0);
+      expect(result.softDeleted).toBe(0);
+      expect(result.errors).toEqual([]);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("counts a row as alive when Synapse returns 200", async () => {
+      mockGroupSelectRows.rows = [
+        { id: "rec-alive", matrixRoomId: "!alive:test.local" },
+      ];
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ room_id: "!alive:test.local" }),
+      });
+
+      const result = await reconcileGroupMatrixRooms();
+
+      expect(result.total).toBe(1);
+      expect(result.alive).toBe(1);
+      expect(result.softDeleted).toBe(0);
+      expect(result.errors).toEqual([]);
+      // No DB update — the row stays live.
+      expect(mockUpdateSet).not.toHaveBeenCalled();
+    });
+
+    it("soft-deletes a row when Synapse returns 404", async () => {
+      mockGroupSelectRows.rows = [
+        { id: "rec-gone", matrixRoomId: "!gone:test.local" },
+      ];
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        json: () => Promise.resolve({ errcode: "M_NOT_FOUND" }),
+      });
+
+      const result = await reconcileGroupMatrixRooms();
+
+      expect(result.total).toBe(1);
+      expect(result.alive).toBe(0);
+      expect(result.softDeleted).toBe(1);
+      expect(result.errors).toEqual([]);
+
+      // Verify the DB write includes a deletedAt timestamp.
+      expect(mockUpdateSet).toHaveBeenCalledTimes(1);
+      const setArgs = mockUpdateSet.mock.calls[0][0];
+      expect(setArgs.deletedAt).toBeInstanceOf(Date);
+    });
+
+    it("records an error and leaves the row alone for non-404 failures", async () => {
+      mockGroupSelectRows.rows = [
+        { id: "rec-err", matrixRoomId: "!err:test.local" },
+      ];
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({ errcode: "M_UNKNOWN" }),
+      });
+
+      const result = await reconcileGroupMatrixRooms();
+
+      expect(result.total).toBe(1);
+      expect(result.alive).toBe(0);
+      expect(result.softDeleted).toBe(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toEqual({
+        recordId: "rec-err",
+        matrixRoomId: "!err:test.local",
+        reason: expect.stringContaining("500"),
+      });
+      expect(mockUpdateSet).not.toHaveBeenCalled();
+    });
+
+    it("captures fetch failures as errors without crashing", async () => {
+      mockGroupSelectRows.rows = [
+        { id: "rec-net", matrixRoomId: "!net:test.local" },
+      ];
+
+      mockFetch.mockRejectedValueOnce(new Error("network down"));
+
+      const result = await reconcileGroupMatrixRooms();
+
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].reason).toBe("network down");
+      expect(result.softDeleted).toBe(0);
+    });
+
+    it("processes multiple rows independently in one pass", async () => {
+      mockGroupSelectRows.rows = [
+        { id: "rec-1", matrixRoomId: "!one:test.local" },
+        { id: "rec-2", matrixRoomId: "!two:test.local" },
+        { id: "rec-3", matrixRoomId: "!three:test.local" },
+      ];
+
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve({}) })
+        .mockResolvedValueOnce({ ok: false, status: 404, json: () => Promise.resolve({}) })
+        .mockResolvedValueOnce({ ok: false, status: 503, json: () => Promise.resolve({}) });
+
+      const result = await reconcileGroupMatrixRooms();
+
+      expect(result.total).toBe(3);
+      expect(result.alive).toBe(1);
+      expect(result.softDeleted).toBe(1);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].recordId).toBe("rec-3");
+    });
+
+    it("treats malformed roomIds as missing without calling Synapse", async () => {
+      mockGroupSelectRows.rows = [
+        { id: "rec-bad", matrixRoomId: "not-a-room-id" },
+      ];
+
+      const result = await reconcileGroupMatrixRooms();
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(result.softDeleted).toBe(1);
+    });
+  });
+
+  describe("reconcileDmRooms", () => {
+    beforeEach(() => {
+      mockDmSelectRows.rows = [];
+      mockGroupSelectRows.rows = [];
+      mockUpdateWhere.mockReset();
+      mockUpdateSet.mockClear();
+    });
+
+    it("returns zero counts when the dm_rooms table is empty", async () => {
+      mockDmSelectRows.rows = [];
+      const result = await reconcileDmRooms();
+      expect(result).toEqual({ total: 0, alive: 0, softDeleted: 0, errors: [] });
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("soft-deletes a missing dm room", async () => {
+      mockDmSelectRows.rows = [
+        { id: "dm-1", matrixRoomId: "!gone:test.local" },
+      ];
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        json: () => Promise.resolve({}),
+      });
+      const result = await reconcileDmRooms();
+      expect(result.softDeleted).toBe(1);
+      expect(mockUpdateSet).toHaveBeenCalledTimes(1);
+      const setArgs = mockUpdateSet.mock.calls[0][0];
+      expect(setArgs.deletedAt).toBeInstanceOf(Date);
+    });
+
+    it("leaves a live dm room alone", async () => {
+      mockDmSelectRows.rows = [
+        { id: "dm-1", matrixRoomId: "!live:test.local" },
+      ];
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({}),
+      });
+      const result = await reconcileDmRooms();
+      expect(result.alive).toBe(1);
+      expect(result.softDeleted).toBe(0);
+      expect(mockUpdateSet).not.toHaveBeenCalled();
+    });
+
+    it("records non-404 errors without tombstoning the row", async () => {
+      mockDmSelectRows.rows = [
+        { id: "dm-err", matrixRoomId: "!err:test.local" },
+      ];
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 502,
+        json: () => Promise.resolve({}),
+      });
+      const result = await reconcileDmRooms();
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].matrixRoomId).toBe("!err:test.local");
+      expect(result.softDeleted).toBe(0);
+    });
+  });
+
+  describe("triggerStartupReconcileGroupMatrixRooms", () => {
+    it("is idempotent across repeated invocations within the same process", () => {
+      // We can't easily observe setImmediate output here, but we can confirm
+      // the function doesn't throw and can be called multiple times safely.
+      expect(() => triggerStartupReconcileGroupMatrixRooms()).not.toThrow();
+      expect(() => triggerStartupReconcileGroupMatrixRooms()).not.toThrow();
     });
   });
 });

--- a/src/lib/erc8004.ts
+++ b/src/lib/erc8004.ts
@@ -1,0 +1,92 @@
+import { getInstanceConfig } from "@/lib/federation/instance-config";
+
+type Erc8004AgentLike = {
+  id: string;
+  name: string;
+  description?: string | null;
+  image?: string | null;
+  parentAgentId?: string | null;
+  metadata?: Record<string, unknown> | null;
+};
+
+export type Erc8004Registration = {
+  standard: "erc-8004";
+  version: "0.1.0";
+  implementation: "offchain-compat";
+  agentId: string;
+  parentAgentId: string | null;
+  name: string;
+  username: string | null;
+  description: string | null;
+  imageUrl: string | null;
+  agentRegistry: string;
+  agentURI: string;
+  registrationFileUrl: string;
+  endpoints: {
+    mcpDiscovery: string;
+    mcpRpc: string;
+    profile: string;
+    manifest: string;
+  };
+  instance: {
+    instanceId: string;
+    instanceType: string;
+    instanceSlug: string;
+    baseUrl: string;
+  };
+};
+
+function getUsername(agent: Pick<Erc8004AgentLike, "metadata">): string | null {
+  const metadata = (agent.metadata ?? {}) as Record<string, unknown>;
+  const username = metadata.username;
+  return typeof username === "string" && username.trim().length > 0 ? username.trim() : null;
+}
+
+function getDescription(agent: Pick<Erc8004AgentLike, "description" | "metadata">): string | null {
+  const metadata = (agent.metadata ?? {}) as Record<string, unknown>;
+  const bio = metadata.bio;
+  if (typeof bio === "string" && bio.trim().length > 0) return bio.trim();
+  return agent.description ?? null;
+}
+
+function getImageUrl(agent: Pick<Erc8004AgentLike, "image">): string | null {
+  return agent.image ?? null;
+}
+
+export function buildErc8004Registration(params: {
+  agent: Erc8004AgentLike;
+  profileUrl: string;
+  manifestUrl: string;
+  registrationFileUrl: string;
+}): Erc8004Registration {
+  const config = getInstanceConfig();
+  const baseUrl = config.baseUrl.replace(/\/+$/, "");
+  const username = getUsername(params.agent);
+
+  return {
+    standard: "erc-8004",
+    version: "0.1.0",
+    implementation: "offchain-compat",
+    agentId: params.agent.id,
+    parentAgentId: params.agent.parentAgentId ?? null,
+    name: params.agent.name,
+    username,
+    description: getDescription(params.agent),
+    imageUrl: getImageUrl(params.agent),
+    agentRegistry: `rivr:${config.instanceId}:${params.agent.id}`,
+    agentURI: params.registrationFileUrl,
+    registrationFileUrl: params.registrationFileUrl,
+    endpoints: {
+      mcpDiscovery: `${baseUrl}/.well-known/mcp`,
+      mcpRpc: `${baseUrl}/api/mcp`,
+      profile: params.profileUrl,
+      manifest: params.manifestUrl,
+    },
+    instance: {
+      instanceId: config.instanceId,
+      instanceType: config.instanceType,
+      instanceSlug: config.instanceSlug,
+      baseUrl,
+    },
+  };
+}

--- a/src/lib/matrix-admin.ts
+++ b/src/lib/matrix-admin.ts
@@ -1,5 +1,7 @@
 "use server";
 
+import { MatrixProvisioningError } from "./matrix-errors";
+
 /**
  * Server-side Matrix Synapse Admin API client.
  *
@@ -18,6 +20,7 @@
  * - `@/lib/env` for `MATRIX_HOMESERVER_URL`, `MATRIX_ADMIN_TOKEN`, `MATRIX_SERVER_NAME`.
  */
 import { getEnv } from "@/lib/env";
+
 
 /**
  * Makes an authenticated request to the Synapse Admin API.
@@ -69,31 +72,62 @@ export async function provisionMatrixUser(params: {
   const serverName = getEnv("MATRIX_SERVER_NAME");
   const matrixUserId = `@${params.localpart}:${serverName}`;
 
-  // Register user via admin API v2
-  await synapseAdminRequest(
-    `/_synapse/admin/v2/users/${encodeURIComponent(matrixUserId)}`,
-    {
-      method: "PUT",
-      body: JSON.stringify({
-        displayname: params.displayName,
-        admin: false,
-        deactivated: false,
-      }),
-    }
-  );
+  // Register user via admin API v2.
+  // PUT is idempotent — Synapse returns 200 if the user already exists, 201 if newly
+  // created. Either is fine for our flow; we just need the row to exist before login.
+  try {
+    await synapseAdminRequest(
+      `/_synapse/admin/v2/users/${encodeURIComponent(matrixUserId)}`,
+      {
+        method: "PUT",
+        body: JSON.stringify({
+          displayname: params.displayName,
+          admin: false,
+          deactivated: false,
+        }),
+      }
+    );
+  } catch (error) {
+    throw new MatrixProvisioningError(
+      "user_create",
+      error instanceof Error ? error.message : String(error),
+      error,
+    );
+  }
 
-  // Get access token for the user
-  const loginResult = await synapseAdminRequest(
-    `/_synapse/admin/v1/users/${encodeURIComponent(matrixUserId)}/login`,
-    {
-      method: "POST",
-      body: JSON.stringify({}),
-    }
-  );
+  // Get an access token for the user. This path also covers re-provisioning
+  // when the caller knows the Synapse user already exists but the local
+  // `matrixAccessToken` column is null (admin login is repeatable).
+  let loginResult: { access_token?: unknown };
+  try {
+    loginResult = await synapseAdminRequest(
+      `/_synapse/admin/v1/users/${encodeURIComponent(matrixUserId)}/login`,
+      {
+        method: "POST",
+        body: JSON.stringify({}),
+      }
+    );
+  } catch (error) {
+    throw new MatrixProvisioningError(
+      "user_login",
+      error instanceof Error ? error.message : String(error),
+      error,
+    );
+  }
+
+  const accessToken = loginResult.access_token;
+  if (typeof accessToken !== "string" || accessToken.length === 0) {
+    // Synapse returned 200 but didn't include a token. Treat as a hard failure
+    // so we never persist a half-provisioned row.
+    throw new MatrixProvisioningError(
+      "missing_token",
+      `Synapse /login returned no access_token for ${matrixUserId}`,
+    );
+  }
 
   return {
     matrixUserId,
-    accessToken: loginResult.access_token,
+    accessToken,
   };
 }
 
@@ -186,4 +220,115 @@ export async function createDirectMessageRoom(params: {
   );
 
   return { roomId: result.room_id };
+}
+
+/**
+ * Lists current room members via the Synapse Admin API.
+ *
+ * Used by `addParticipantsToRoom` to decide whether the target room is a
+ * 1:1 DM (2 members) that should be promoted to a group room when extra
+ * participants are added.
+ *
+ * @param roomId - Synapse room ID (must start with `!`)
+ * @returns Array of full Matrix user IDs currently joined to the room
+ */
+export async function getRoomMembers(roomId: string): Promise<string[]> {
+  if (!roomId.startsWith("!")) {
+    throw new Error(`Invalid Matrix roomId: ${roomId}`);
+  }
+  const result = await synapseAdminRequest(
+    `/_synapse/admin/v1/rooms/${encodeURIComponent(roomId)}/members`,
+    { method: "GET" },
+  );
+  const members = (result?.members as unknown) ?? [];
+  if (!Array.isArray(members)) return [];
+  return members.filter((m): m is string => typeof m === "string");
+}
+
+/**
+ * Creates a new Matrix room with multiple invitees via Synapse Admin API.
+ * Used when promoting a 1:1 DM to a group chat — the original two members
+ * plus the new participants are all invited into a fresh room.
+ *
+ * @param params.creatorUserId - Full Matrix user ID who will be the room creator
+ * @param params.inviteeUserIds - Full Matrix user IDs to invite (creator excluded)
+ * @param params.name - Optional room display name
+ * @returns The newly created Matrix room ID
+ */
+export async function createGroupRoomAsAdmin(params: {
+  creatorUserId: string;
+  inviteeUserIds: string[];
+  name?: string;
+}): Promise<{ roomId: string }> {
+  const result = await synapseAdminRequest(`/_synapse/admin/v1/rooms`, {
+    method: "POST",
+    body: JSON.stringify({
+      creator: params.creatorUserId,
+      invite: params.inviteeUserIds,
+      // `is_direct` stays false here: the room is a group chat even if the
+      // promotion path originated from a DM. The DM-specific m.direct
+      // mirror tracking is removed by the caller after promotion.
+      is_direct: false,
+      preset: "trusted_private_chat",
+      name: params.name,
+    }),
+  });
+  return { roomId: result.room_id };
+}
+
+/**
+ * Posts a server-side system message via the Synapse client API using the
+ * admin token. We don't have the sender's per-user access token here, so
+ * we impersonate via the admin endpoint and use the special m.notice msg
+ * type to render as a system event rather than a user-typed message.
+ *
+ * @param params.senderUserId - Full Matrix user ID to attribute the post to
+ * @param params.roomId - Target Matrix room ID
+ * @param params.body - Text body of the notice
+ */
+export async function postSystemNotice(params: {
+  senderUserId: string;
+  roomId: string;
+  body: string;
+}): Promise<{ eventId: string }> {
+  if (!params.roomId.startsWith("!")) {
+    throw new Error(`Invalid Matrix roomId: ${params.roomId}`);
+  }
+  if (!params.senderUserId.startsWith("@")) {
+    throw new Error(`Invalid Matrix userId: ${params.senderUserId}`);
+  }
+
+  const homeserverUrl = getEnv("MATRIX_HOMESERVER_URL");
+  const adminToken = getEnv("MATRIX_ADMIN_TOKEN");
+  const txnId = `system-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+
+  // `user_id` query parameter lets the admin token impersonate the user
+  // for sending the event. Supported by Synapse admin API.
+  const url = new URL(
+    `${homeserverUrl}/_matrix/client/v3/rooms/${encodeURIComponent(params.roomId)}/send/m.room.message/${encodeURIComponent(txnId)}`,
+  );
+  url.searchParams.set("user_id", params.senderUserId);
+
+  const response = await fetch(url.toString(), {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${adminToken}`,
+    },
+    body: JSON.stringify({
+      msgtype: "m.notice",
+      body: params.body,
+    }),
+  });
+
+  if (!response.ok) {
+    const errBody = await response.json().catch(() => ({}));
+    throw new Error(
+      `Synapse send error: ${response.status} - ${JSON.stringify(errBody)}`,
+    );
+  }
+
+  const result = await response.json().catch(() => ({}));
+  const eventId = typeof result?.event_id === "string" ? result.event_id : "";
+  return { eventId };
 }

--- a/src/lib/matrix-client.ts
+++ b/src/lib/matrix-client.ts
@@ -17,9 +17,105 @@
  * - `matrix-js-sdk` for the underlying Matrix protocol client.
  */
 import { ClientEvent, createClient, EventType, MatrixClient, MsgType, Preset, Room } from "matrix-js-sdk";
-import { ensureUserJoinedRoom } from "@/app/actions/matrix";
+import { ensureUserJoinedRoom, recordDmRoomMirror } from "@/app/actions/matrix";
+import {
+  emitMatrixSyncRepair,
+  MATRIX_SYNC_REPAIR_EXHAUSTED,
+  MATRIX_SYNC_REPAIR_FAILED,
+  MATRIX_SYNC_REPAIR_SUCCEEDED,
+} from "@/lib/matrix-sync-events";
 
 let matrixClient: MatrixClient | null = null;
+
+// ─── Retry tuning for m.direct repair ───────────────────────────────────────
+// Repair runs once during startSync. Network blips and Synapse rate-limits
+// are short-lived; bounded exponential backoff catches them without looping
+// forever on a misconfigured server.
+const M_DIRECT_REPAIR_MAX_ATTEMPTS = 4;
+const M_DIRECT_REPAIR_BASE_DELAY_MS = 400;
+const M_DIRECT_REPAIR_BACKOFF_FACTOR = 2;
+const M_DIRECT_REPAIR_MAX_DELAY_MS = 5_000;
+
+/**
+ * Error thrown when m.direct repair fails for every retry attempt during
+ * `startSync()`. The sync proceeds, but the caller knows the DM mirror is
+ * potentially stale until the user refreshes or the next sync runs.
+ */
+export class MatrixDirectRepairError extends Error {
+  public readonly attempts: number;
+  public readonly lastErrorMessage: string;
+  constructor(attempts: number, lastErrorMessage: string) {
+    super(
+      `Failed to persist m.direct after ${attempts} attempts: ${lastErrorMessage}`,
+    );
+    this.name = "MatrixDirectRepairError";
+    this.attempts = attempts;
+    this.lastErrorMessage = lastErrorMessage;
+  }
+}
+
+function describeError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  return String(err);
+}
+
+function computeBackoffMs(attemptIndex: number): number {
+  // Exponential backoff capped at M_DIRECT_REPAIR_MAX_DELAY_MS so the worst
+  // case stays bounded even if the constants are tuned upward later.
+  const raw = M_DIRECT_REPAIR_BASE_DELAY_MS * Math.pow(M_DIRECT_REPAIR_BACKOFF_FACTOR, attemptIndex);
+  return Math.min(raw, M_DIRECT_REPAIR_MAX_DELAY_MS);
+}
+
+/**
+ * Persist `m.direct` account data with bounded exponential backoff.
+ *
+ * On every failure, emits `MATRIX_SYNC_REPAIR_FAILED`. On success, emits
+ * `MATRIX_SYNC_REPAIR_SUCCEEDED`. If every attempt fails, emits
+ * `MATRIX_SYNC_REPAIR_EXHAUSTED` and throws `MatrixDirectRepairError`.
+ *
+ * Exported for tests; production callers go through `startSync`.
+ */
+export async function persistMDirectWithRetry(
+  client: MatrixClient,
+  directContent: Record<string, string[]>,
+): Promise<void> {
+  let lastError: unknown = null;
+
+  for (let attempt = 1; attempt <= M_DIRECT_REPAIR_MAX_ATTEMPTS; attempt++) {
+    try {
+      await client.setAccountData(EventType.Direct, directContent);
+      emitMatrixSyncRepair({ type: MATRIX_SYNC_REPAIR_SUCCEEDED, attempt });
+      return;
+    } catch (err) {
+      lastError = err;
+      const isFinalAttempt = attempt === M_DIRECT_REPAIR_MAX_ATTEMPTS;
+      const nextRetryMs = isFinalAttempt ? null : computeBackoffMs(attempt - 1);
+      emitMatrixSyncRepair({
+        type: MATRIX_SYNC_REPAIR_FAILED,
+        attempt,
+        maxAttempts: M_DIRECT_REPAIR_MAX_ATTEMPTS,
+        nextRetryMs,
+        message: describeError(err),
+      });
+      console.error(
+        `[matrix] m.direct repair failed (attempt ${attempt}/${M_DIRECT_REPAIR_MAX_ATTEMPTS}):`,
+        err,
+      );
+      if (!isFinalAttempt && nextRetryMs !== null) {
+        await new Promise((resolve) => setTimeout(resolve, nextRetryMs));
+      }
+    }
+  }
+
+  const finalMessage = describeError(lastError);
+  emitMatrixSyncRepair({
+    type: MATRIX_SYNC_REPAIR_EXHAUSTED,
+    attempts: M_DIRECT_REPAIR_MAX_ATTEMPTS,
+    message: finalMessage,
+  });
+  throw new MatrixDirectRepairError(M_DIRECT_REPAIR_MAX_ATTEMPTS, finalMessage);
+}
 
 /**
  * Creates or returns the cached MatrixClient instance.
@@ -115,12 +211,24 @@ export async function startSync(client: MatrixClient): Promise<void> {
     }
   }
 
-  // Persist updated m.direct if we found new DM rooms
+  // Persist updated m.direct if we found new DM rooms.
+  // Failures are emitted via matrix-sync-events so the UI can surface them;
+  // we don't rethrow here because the sync itself succeeded — we just couldn't
+  // mirror the discovered DM rooms back to the account data.
   if (directContentChanged) {
     try {
-      await client.setAccountData(EventType.Direct, directContent as Record<string, string[]>);
+      await persistMDirectWithRetry(
+        client,
+        directContent as Record<string, string[]>,
+      );
     } catch (err) {
-      console.error("[matrix] Failed to update m.direct account data:", err);
+      // Already emitted MATRIX_SYNC_REPAIR_EXHAUSTED inside the helper.
+      // Swallow here so startSync() resolves; subscribers receive the
+      // exhausted event and can prompt the user.
+      if (!(err instanceof MatrixDirectRepairError)) {
+        // Should not happen, but be defensive about unexpected errors.
+        console.error("[matrix] Unexpected error from persistMDirectWithRetry:", err);
+      }
     }
   }
 }
@@ -167,7 +275,14 @@ export async function sendMessage(
  */
 export async function getOrCreateDmRoom(
   client: MatrixClient,
-  targetUserId: string
+  targetUserId: string,
+  /**
+   * Optional RIVR agent id for the target user. If supplied, the new room
+   * is mirrored into the `dm_rooms` table via `recordDmRoomMirror` so the
+   * pairing survives a homeserver migration. The caller already knows this
+   * id because it just resolved the targetUserId from `getDmRoomForUser`.
+   */
+  targetAgentId?: string,
 ): Promise<string> {
   // Check existing DM rooms
   const rooms = client.getRooms();
@@ -207,6 +322,17 @@ export async function getOrCreateDmRoom(
   ];
   await client.setAccountData(EventType.Direct, directContent as Record<string, string[]>);
 
+  // Mirror the room to RIVR's dm_rooms table for migration survival.
+  // Best-effort: a failure here is logged server-side and recovered by
+  // the reconcile job; the DM itself is still usable client-side.
+  if (targetAgentId) {
+    try {
+      await recordDmRoomMirror(result.room_id, [targetAgentId]);
+    } catch (err) {
+      console.error("[matrix] getOrCreateDmRoom mirror write failed:", err);
+    }
+  }
+
   return result.room_id;
 }
 
@@ -223,7 +349,13 @@ export async function getOrCreateDmRoom(
 export async function createGroupDmRoom(
   client: MatrixClient,
   targetUserIds: string[],
-  roomName?: string
+  roomName?: string,
+  /**
+   * Optional RIVR agent ids matching `targetUserIds` (same order or any
+   * order — we just record the set). When supplied, the new room is
+   * mirrored into the `dm_rooms` table for migration survival.
+   */
+  targetAgentIds?: string[],
 ): Promise<string> {
   const result = await client.createRoom({
     is_direct: true,
@@ -247,6 +379,15 @@ export async function createGroupDmRoom(
     ];
   }
   await client.setAccountData(EventType.Direct, directContent as Record<string, string[]>);
+
+  // Mirror the room to RIVR's dm_rooms table for migration survival.
+  if (targetAgentIds && targetAgentIds.length > 0) {
+    try {
+      await recordDmRoomMirror(result.room_id, targetAgentIds);
+    } catch (err) {
+      console.error("[matrix] createGroupDmRoom mirror write failed:", err);
+    }
+  }
 
   return result.room_id;
 }

--- a/src/lib/matrix-errors.ts
+++ b/src/lib/matrix-errors.ts
@@ -1,0 +1,25 @@
+/**
+ * Error types for Matrix admin API operations. Lives in its own module so
+ * the canonical `matrix-admin.ts` can stay marked `"use server"` (which
+ * forbids non-async exports like classes).
+ */
+
+/**
+ * Typed error for Matrix provisioning failures so callers can distinguish
+ * "Synapse rejected us" from "we got back a malformed login result" from
+ * generic network errors.
+ */
+export class MatrixProvisioningError extends Error {
+  public readonly stage:
+    | "user_create"
+    | "user_login"
+    | "missing_token"
+    | "network";
+  public readonly cause?: unknown;
+  constructor(stage: MatrixProvisioningError["stage"], message: string, cause?: unknown) {
+    super(`Matrix provisioning failed (${stage}): ${message}`);
+    this.name = "MatrixProvisioningError";
+    this.stage = stage;
+    this.cause = cause;
+  }
+}

--- a/src/lib/matrix-groups.ts
+++ b/src/lib/matrix-groups.ts
@@ -20,10 +20,10 @@
  * - `@/db` for group_matrix_rooms table operations.
  * - `@/db/schema` for table definitions.
  */
-import { eq } from "drizzle-orm";
+import { and, eq, isNull, sql } from "drizzle-orm";
 import { getEnv } from "@/lib/env";
 import { db } from "@/db";
-import { agents, groupMatrixRooms, type ChatMode } from "@/db/schema";
+import { agents, groupMatrixRooms, dmRooms, type ChatMode } from "@/db/schema";
 
 /**
  * Makes an authenticated request to the Synapse Admin API.
@@ -69,9 +69,13 @@ export async function createGroupMatrixRoom(params: {
   creatorMatrixUserId: string;
   chatMode?: ChatMode;
 }): Promise<{ matrixRoomId: string; recordId: string }> {
-  // Check if room already exists for this group
+  // Check if a live (not soft-deleted) room already exists for this group.
+  // Tombstoned rows must not be reused — their Synapse room has been purged.
   const existing = await db.query.groupMatrixRooms.findFirst({
-    where: eq(groupMatrixRooms.groupAgentId, params.groupAgentId),
+    where: and(
+      eq(groupMatrixRooms.groupAgentId, params.groupAgentId),
+      isNull(groupMatrixRooms.deletedAt),
+    ),
   });
 
   if (existing) {
@@ -119,7 +123,10 @@ export async function inviteToGroupRoom(params: {
   targetAgentId: string;
 }): Promise<void> {
   const groupRoom = await db.query.groupMatrixRooms.findFirst({
-    where: eq(groupMatrixRooms.groupAgentId, params.groupAgentId),
+    where: and(
+      eq(groupMatrixRooms.groupAgentId, params.groupAgentId),
+      isNull(groupMatrixRooms.deletedAt),
+    ),
   });
 
   if (!groupRoom) {
@@ -160,7 +167,10 @@ export async function removeFromGroupRoom(params: {
   targetAgentId: string;
 }): Promise<void> {
   const groupRoom = await db.query.groupMatrixRooms.findFirst({
-    where: eq(groupMatrixRooms.groupAgentId, params.groupAgentId),
+    where: and(
+      eq(groupMatrixRooms.groupAgentId, params.groupAgentId),
+      isNull(groupMatrixRooms.deletedAt),
+    ),
   });
 
   if (!groupRoom) return; // No room to remove from
@@ -219,6 +229,265 @@ export async function setGroupChatMode(params: {
  */
 export async function getGroupMatrixRoom(groupAgentId: string) {
   return db.query.groupMatrixRooms.findFirst({
-    where: eq(groupMatrixRooms.groupAgentId, groupAgentId),
+    where: and(
+      eq(groupMatrixRooms.groupAgentId, groupAgentId),
+      isNull(groupMatrixRooms.deletedAt),
+    ),
   }) ?? null;
+}
+
+// ─── Reconciliation ─────────────────────────────────────────────────────────
+
+/**
+ * Result of one reconciliation pass over the `group_matrix_rooms` table.
+ */
+export interface ReconcileGroupMatrixRoomsResult {
+  /** Total rows considered (rows that are not already soft-deleted). */
+  total: number;
+  /** Rooms confirmed to still exist in Synapse. */
+  alive: number;
+  /** Rows newly tombstoned because Synapse returned 404. */
+  softDeleted: number;
+  /** Errors encountered (network, non-404 Synapse responses, DB write failures). */
+  errors: Array<{ recordId: string; matrixRoomId: string; reason: string }>;
+}
+
+/**
+ * Probes Synapse for room existence via the admin API. Resolves to:
+ * - `"alive"` on 2xx
+ * - `"missing"` on 404
+ * - `"error"` for everything else (including network failures)
+ *
+ * Exported separately from `reconcileGroupMatrixRooms` so the dmRooms
+ * reconciler (in matrix-client) can reuse the exact same probing logic.
+ */
+export async function probeMatrixRoomExistence(
+  matrixRoomId: string,
+): Promise<{ status: "alive" } | { status: "missing" } | { status: "error"; reason: string }> {
+  if (!matrixRoomId.startsWith("!")) {
+    // Synapse room IDs always start with "!"; anything else is malformed and
+    // never resolves. Treat as missing so the row is tombstoned and a fresh
+    // room can be created next time.
+    return { status: "missing" };
+  }
+
+  const homeserverUrl = getEnv("MATRIX_HOMESERVER_URL");
+  const adminToken = getEnv("MATRIX_ADMIN_TOKEN");
+
+  if (!homeserverUrl || !adminToken) {
+    return {
+      status: "error",
+      reason: "Matrix admin credentials not configured (MATRIX_HOMESERVER_URL/MATRIX_ADMIN_TOKEN)",
+    };
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(
+      `${homeserverUrl}/_synapse/admin/v1/rooms/${encodeURIComponent(matrixRoomId)}`,
+      {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${adminToken}`,
+        },
+      },
+    );
+  } catch (err) {
+    return {
+      status: "error",
+      reason: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  if (response.ok) return { status: "alive" };
+  if (response.status === 404) return { status: "missing" };
+
+  let body: unknown = {};
+  try {
+    body = await response.json();
+  } catch {
+    // Swallow — we only need the status for the error reason.
+  }
+  return {
+    status: "error",
+    reason: `Synapse responded ${response.status}: ${JSON.stringify(body)}`,
+  };
+}
+
+/**
+ * Reconcile the `group_matrix_rooms` table against Synapse. For every live
+ * (non-soft-deleted) row, probes Synapse for the room. If Synapse returns
+ * 404, the row is marked `deletedAt = now()`. Other errors are logged and
+ * the row is left alone so a future pass can retry.
+ *
+ * Safe to run repeatedly. Non-destructive — never hard-deletes a row, so the
+ * historical mapping survives for audit / migration replay.
+ *
+ * @returns Counts and per-row error details for observability.
+ */
+export async function reconcileGroupMatrixRooms(): Promise<ReconcileGroupMatrixRoomsResult> {
+  const rows = await db
+    .select({
+      id: groupMatrixRooms.id,
+      matrixRoomId: groupMatrixRooms.matrixRoomId,
+    })
+    .from(groupMatrixRooms)
+    .where(isNull(groupMatrixRooms.deletedAt));
+
+  const result: ReconcileGroupMatrixRoomsResult = {
+    total: rows.length,
+    alive: 0,
+    softDeleted: 0,
+    errors: [],
+  };
+
+  for (const row of rows) {
+    const probe = await probeMatrixRoomExistence(row.matrixRoomId);
+
+    if (probe.status === "alive") {
+      result.alive += 1;
+      continue;
+    }
+
+    if (probe.status === "missing") {
+      try {
+        await db
+          .update(groupMatrixRooms)
+          .set({ deletedAt: new Date(), updatedAt: new Date() })
+          .where(eq(groupMatrixRooms.id, row.id));
+        result.softDeleted += 1;
+      } catch (err) {
+        // DB write failure leaves the row alive — next pass will retry.
+        const reason = err instanceof Error ? err.message : String(err);
+        result.errors.push({ recordId: row.id, matrixRoomId: row.matrixRoomId, reason });
+        console.error(
+          `[matrix] reconcileGroupMatrixRooms: failed to soft-delete row ${row.id} (${row.matrixRoomId}):`,
+          err,
+        );
+      }
+      continue;
+    }
+
+    // probe.status === "error" — log and continue per spec.
+    result.errors.push({
+      recordId: row.id,
+      matrixRoomId: row.matrixRoomId,
+      reason: probe.reason,
+    });
+    console.error(
+      `[matrix] reconcileGroupMatrixRooms: Synapse probe failed for ${row.matrixRoomId}: ${probe.reason}`,
+    );
+  }
+
+  return result;
+}
+
+/**
+ * Module-level latch so we only kick off the lazy startup reconcile once per
+ * Node process. The instrumentation hook fires on every cold start, but we
+ * don't want to launch a second pass mid-server when something else (e.g. a
+ * future hot-reload trigger) imports this module.
+ */
+
+
+// ─── dmRooms reconciliation ─────────────────────────────────────────────────
+
+/**
+ * Reconciles the `dm_rooms` mirror against Synapse, using the same
+ * `probeMatrixRoomExistence` helper as `reconcileGroupMatrixRooms`. Rows
+ * whose underlying Synapse room returned 404 are soft-deleted; other errors
+ * are surfaced and the row is left alive.
+ */
+export async function reconcileDmRooms(): Promise<ReconcileGroupMatrixRoomsResult> {
+  const rows = await db
+    .select({
+      id: dmRooms.id,
+      matrixRoomId: dmRooms.matrixRoomId,
+    })
+    .from(dmRooms)
+    .where(isNull(dmRooms.deletedAt));
+
+  const result: ReconcileGroupMatrixRoomsResult = {
+    total: rows.length,
+    alive: 0,
+    softDeleted: 0,
+    errors: [],
+  };
+
+  for (const row of rows) {
+    const probe = await probeMatrixRoomExistence(row.matrixRoomId);
+
+    if (probe.status === "alive") {
+      result.alive += 1;
+      continue;
+    }
+
+    if (probe.status === "missing") {
+      try {
+        await db
+          .update(dmRooms)
+          .set({ deletedAt: new Date(), updatedAt: new Date() })
+          .where(eq(dmRooms.id, row.id));
+        result.softDeleted += 1;
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        result.errors.push({ recordId: row.id, matrixRoomId: row.matrixRoomId, reason });
+        console.error(
+          `[matrix] reconcileDmRooms: failed to soft-delete row ${row.id} (${row.matrixRoomId}):`,
+          err,
+        );
+      }
+      continue;
+    }
+
+    result.errors.push({
+      recordId: row.id,
+      matrixRoomId: row.matrixRoomId,
+      reason: probe.reason,
+    });
+    console.error(
+      `[matrix] reconcileDmRooms: Synapse probe failed for ${row.matrixRoomId}: ${probe.reason}`,
+    );
+  }
+
+  return result;
+}
+
+/**
+ * Returns DM room mirror rows for a given RIVR agent. Used as a fallback
+ * when Matrix sync is degraded — the UI can still rebuild the conversation
+ * list from the RIVR-side mirror even if the client can't sync m.direct.
+ *
+ * @param agentId - RIVR agent ID (UUID); rows where this id appears in the
+ *   `participants` JSON array are returned.
+ */
+export async function listDmRoomsForActor(agentId: string): Promise<
+  { id: string; matrixRoomId: string; participants: string[]; createdAt: Date; updatedAt: Date }[]
+> {
+  if (!agentId) return [];
+  // `jsonb @> '["agent-id"]'::jsonb` matches when the array contains the id.
+  // Drizzle doesn't have a typed jsonb-contains helper, so use the sql tag.
+  const rows = await db
+    .select({
+      id: dmRooms.id,
+      matrixRoomId: dmRooms.matrixRoomId,
+      participants: dmRooms.participants,
+      createdAt: dmRooms.createdAt,
+      updatedAt: dmRooms.updatedAt,
+    })
+    .from(dmRooms)
+    .where(
+      and(
+        isNull(dmRooms.deletedAt),
+        sql`${dmRooms.participants} @> ${JSON.stringify([agentId])}::jsonb`,
+      ),
+    );
+  return rows.map((r) => ({
+    id: r.id,
+    matrixRoomId: r.matrixRoomId,
+    participants: (r.participants as string[] | null) ?? [],
+    createdAt: r.createdAt,
+    updatedAt: r.updatedAt,
+  }));
 }

--- a/src/lib/matrix-startup.ts
+++ b/src/lib/matrix-startup.ts
@@ -1,0 +1,43 @@
+/**
+ * Startup hook for matrix room reconciliation. Lives in its own module so
+ * the canonical `matrix-groups.ts` can stay marked `"use server"` (which
+ * forbids non-async function exports).
+ */
+import { reconcileGroupMatrixRooms, reconcileDmRooms } from "./matrix-groups";
+
+let startupReconcileTriggered = false;
+
+/**
+ * Non-blocking reconcile fired once per cold start. Idempotent: subsequent
+ * calls within the same process are no-ops.
+ */
+export function triggerStartupReconcileGroupMatrixRooms(): void {
+  if (startupReconcileTriggered) return;
+  startupReconcileTriggered = true;
+
+  setImmediate(() => {
+    void (async () => {
+      try {
+        const groups = await reconcileGroupMatrixRooms();
+        if (groups.softDeleted > 0 || groups.errors.length > 0) {
+          console.log(
+            `[matrix] startup reconcile (groups): ${groups.total} rows, ${groups.alive} alive, ${groups.softDeleted} soft-deleted, ${groups.errors.length} errors`,
+          );
+        }
+      } catch (err) {
+        console.error("[matrix] startup reconcileGroupMatrixRooms crashed:", err);
+      }
+
+      try {
+        const dms = await reconcileDmRooms();
+        if (dms.softDeleted > 0 || dms.errors.length > 0) {
+          console.log(
+            `[matrix] startup reconcile (dms): ${dms.total} rows, ${dms.alive} alive, ${dms.softDeleted} soft-deleted, ${dms.errors.length} errors`,
+          );
+        }
+      } catch (err) {
+        console.error("[matrix] startup reconcileDmRooms crashed:", err);
+      }
+    })();
+  });
+}

--- a/src/lib/matrix-sync-events.ts
+++ b/src/lib/matrix-sync-events.ts
@@ -1,0 +1,99 @@
+/**
+ * Browser-side event bus for Matrix sync-repair status.
+ *
+ * Purpose:
+ * - Surface Matrix sync-time repair failures (notably `setAccountData(m.direct)`
+ *   failures during `startSync()`) so UI layers can show toasts or banners.
+ * - Provide a typed, dependency-free pub/sub that works in client components
+ *   without dragging in node `events` or a global emitter library.
+ *
+ * Event types:
+ * - `m_direct_repair_failed`  — every failed attempt during a retry cycle.
+ * - `m_direct_repair_succeeded` — emitted once when the repair finally lands.
+ * - `m_direct_repair_exhausted` — emitted when all retries fail; the UI should
+ *   warn the user that DM tracking may be stale until they refresh.
+ *
+ * Dependencies: none — intentionally pure so this can be imported from
+ *   client components without pulling SSR-only modules.
+ */
+
+/** Event names emitted by the sync-repair bus. */
+export const MATRIX_SYNC_REPAIR_FAILED = "m_direct_repair_failed" as const;
+export const MATRIX_SYNC_REPAIR_SUCCEEDED = "m_direct_repair_succeeded" as const;
+export const MATRIX_SYNC_REPAIR_EXHAUSTED = "m_direct_repair_exhausted" as const;
+
+/** Discriminated union of sync-repair events. */
+export type MatrixSyncRepairEvent =
+  | {
+      type: typeof MATRIX_SYNC_REPAIR_FAILED;
+      /** 1-indexed attempt number that failed. */
+      attempt: number;
+      /** Total attempts that will be made before giving up. */
+      maxAttempts: number;
+      /** Delay (ms) before the next retry, or null on final attempt. */
+      nextRetryMs: number | null;
+      /** Human-readable error message captured from the underlying failure. */
+      message: string;
+    }
+  | {
+      type: typeof MATRIX_SYNC_REPAIR_SUCCEEDED;
+      /** 1-indexed attempt that succeeded. */
+      attempt: number;
+    }
+  | {
+      type: typeof MATRIX_SYNC_REPAIR_EXHAUSTED;
+      /** Total attempts made before giving up. */
+      attempts: number;
+      /** Human-readable error message captured from the final failure. */
+      message: string;
+    };
+
+/** Listener signature for sync-repair subscribers. */
+export type MatrixSyncRepairListener = (event: MatrixSyncRepairEvent) => void;
+
+const listeners = new Set<MatrixSyncRepairListener>();
+
+/**
+ * Subscribe to Matrix sync-repair events.
+ *
+ * @param listener Callback invoked synchronously for every emitted event.
+ * @returns An unsubscribe function. Always call it during cleanup to avoid leaks.
+ * @example
+ * ```ts
+ * const off = onMatrixSyncRepair((evt) => { if (evt.type === MATRIX_SYNC_REPAIR_EXHAUSTED) toast.error(evt.message); });
+ * // ...later
+ * off();
+ * ```
+ */
+export function onMatrixSyncRepair(listener: MatrixSyncRepairListener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/**
+ * Emit a sync-repair event to all subscribers. Internal use by matrix-client.
+ *
+ * @param event The event payload to broadcast.
+ */
+export function emitMatrixSyncRepair(event: MatrixSyncRepairEvent): void {
+  // Iterate over a snapshot so listeners that unsubscribe during dispatch
+  // don't disturb the iteration order.
+  for (const listener of Array.from(listeners)) {
+    try {
+      listener(event);
+    } catch (err) {
+      // A faulty listener must not break the dispatch loop or downstream UI.
+      console.error("[matrix-sync-events] Listener threw:", err);
+    }
+  }
+}
+
+/**
+ * Remove all listeners. Test-only helper; production code should always
+ * use the unsubscribe function returned by `onMatrixSyncRepair`.
+ */
+export function clearMatrixSyncRepairListenersForTesting(): void {
+  listeners.clear();
+}


### PR DESCRIPTION
## Summary
Ports the Matrix messaging overhaul (commits `4e478ae..9f52141` from rivr-social/rivr-app testA) into rivr-person so Camalot's RIVR app surfaces the new Telegram-style threads UI at `rivr.camalot.me/messages`.

Five commits in this PR:
- `3469493` core matrix-client/admin/groups + sync-events + retry
- `df8a356` add-to-chat dialog + sync-exhausted toast in messages UI
- `536f2cf` `group_matrix_rooms.deletedAt` + `dm_rooms` mirror table
- `28f897c` admin reconcile endpoint for groupMatrixRooms + dmRooms
- `20e4220` restore `lib/erc8004` (build dep, referenced by pre-existing myprofile route)

Six commits from the source range were intentionally skipped (decomposed-apps-tree-specific to apps/global, or already at parity on person via the prior `f4720a4` federation-auth port).

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec next build --no-lint` clean (`/messages` route 270 kB / 423 kB First Load JS)
- [x] Deployed to Camalot (`pmdl_rivr_person`, image `rivr:person=b3ed52ca665e`); `rivr.camalot.me/api/health` returns 200, `/messages` returns 41,971-byte new-UI bundle
- [x] Migrations `0049_*` and `0050_*` (group_matrix_rooms.deletedAt + dm_rooms) applied to Camalot's `rivr_person` DB; partial unique indexes in place
- [x] No regression on federation: federationtester `camalot.me` → `FederationOK: true`, Synapse healthy
- [ ] Vitest blocked locally on Node 20.9 vs vitest-4 needing Node 22 — run on Hetzner CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)